### PR TITLE
Prevent extra price api calls

### DIFF
--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -239,10 +239,6 @@ export const Widget: React.FC<WidgetProps> = props => {
       typeof amount === 'string' && amount.startsWith('-');
     let cleanAmount: any;
 
-    if ((isFiat && price === 0) || price === undefined) {
-      getPrice();
-    }
-
     if (invalidAmount) {
       setDisabled(true);
       setErrorMsg('Amount should be a number');

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -234,12 +234,6 @@ export const Widget: React.FC<WidgetProps> = props => {
   }, [to, amount]);
 
   useEffect(() => {
-    if (isFiat && props.price === 0) {
-      getPrice();
-    }
-  }, []);
-
-  useEffect(() => {
     const invalidAmount = amount !== undefined && amount && isNaN(+amount);
     const isNegativeNumber =
       typeof amount === 'string' && amount.startsWith('-');


### PR DESCRIPTION
Removing what I believe are superfluous api calls in the Widget component. Its parent component already has a similar function and passes the price data to Widget as a prop, so seems unnecessary here 