### PR TITLE
fix(issue-157): switch docsify to port 3001

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "docsify-cli": "^4.4.2"
   },
   "scripts": {
-    "serve": "npx docsify serve"
+    "serve": "npx docsify serve --port 3001"
   },
   "author": "",
   "license": "MIT"


### PR DESCRIPTION
Description: switch dev docs to port 3001

Test Plan: inside docs folder, `npm run serve`, should run docsify on port 3001