### PR TITLE
chore(issue-161): add basic renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,9 @@
+{
+    "packageRules": [
+      {
+        "matchUpdateTypes": ["patch"],
+        "automerge": false,
+      }
+    ],
+    "prConcurrentLimit": 2
+  }


### PR DESCRIPTION
Description: adds basic renovate config, setting automerge as false for now, and number of concurrent PRs to 2, as to keep up with review.

