### PR TITLE
Issue 152 - adding support for XEC - Remove sats and bits as currencies

### DIFF
--- a/react/src/components/PayButton/PayButton.tsx
+++ b/react/src/components/PayButton/PayButton.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 
 import { Theme, ThemeName, ThemeProvider, useTheme } from '../../themes';
 import Button, { ButtonProps } from '../Button/Button';
-import { currency } from '../Widget/WidgetContainer';
+import { currency } from '../../util/api-client';
 import { PaymentDialog } from '../PaymentDialog/PaymentDialog';
 import { isValidCashAddress, isValidXecAddress } from '../../util/address';
 

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -183,11 +183,7 @@ export const Widget: React.FC<WidgetProps> = props => {
   const query: string[] = [];
   const isMissingWidgetContainer = !totalReceived;
   const addressDetails = useAddressDetails(to, isMissingWidgetContainer);
-  const isFiat: boolean =
-    currency !== 'SAT' &&
-    currency !== 'BCH' &&
-    currency !== 'bits' &&
-    currency !== 'XEC';
+  const isFiat: boolean = currency !== 'BCH' && currency !== 'XEC';
   const hasPrice: boolean = price !== undefined && price > 0;
   let prefixedAddress: string;
 
@@ -293,8 +289,7 @@ export const Widget: React.FC<WidgetProps> = props => {
       const notZeroValue: boolean =
         currencyObj?.satoshis !== undefined && currencyObj.satoshis > 0;
       if (!isFiat && currencyObj && notZeroValue) {
-        const bchType: string =
-          currency === 'SAT' ? 'satoshis' : currencyObj.currency;
+        const bchType: string = currencyObj.currency;
         setText(`Send ${currencyObj.string} ${bchType}`);
         query.push(`amount=${currencyObj.BCHstring}`);
         url = prefixedAddress + (query.length ? `?${query.join('&')}` : '');
@@ -369,29 +364,18 @@ export const Widget: React.FC<WidgetProps> = props => {
   };
 
   useEffect(() => {
-    const inSatoshis = getCurrencyObject(totalSatsReceived, 'SAT');
+    // const inSatoshis = getCurrencyObject(totalSatsReceived, 'SAT');
+    const progress = getCurrencyObject(totalSatsReceived, currency);
 
     const goal = getCurrencyObject(cleanGoalAmount, currency);
 
     if (!isFiat) {
-      if (goal !== undefined && inSatoshis.float > 0) {
-        setGoalPercent((100 * inSatoshis.float) / goal.satoshis!);
-        if (currency === 'bits') {
-          const bitstring = getCurrencyObject(
-            parseFloat((inSatoshis.float / 100).toFixed(0)),
-            'bits',
-          );
-          setGoalText(`${bitstring.string} / ${goal.string}`);
-          setIsLoading(false);
-        } else if (currency === 'SAT') {
-          setGoalText(`${inSatoshis.string} / ${goal.string}`);
-          setIsLoading(false);
-        } else {
-          const string = inSatoshis.BCHstring!;
-          const truncated = parseFloat(string).toFixed(2);
-          setGoalText(`${truncated} / ${cleanGoalAmount}`);
-          setIsLoading(false);
-        }
+      if (goal !== undefined && progress.float > 0) {
+        setGoalPercent((100 * progress.float) / goal.float);
+        const string = progress.BCHstring!;
+        const truncated = parseFloat(string).toFixed(2);
+        setGoalText(`${truncated} / ${cleanGoalAmount}`);
+        setIsLoading(false);
       }
     } else {
       if (totalSatsReceived !== 0 && hasPrice) {

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -24,14 +24,11 @@ import {
   currencyObject,
 } from '../../util/satoshis';
 import { useAddressDetails } from '../../hooks/useAddressDetails';
-import { fiatCurrency, getSatoshiBalance } from '../../util/api-client';
+import { currency, getSatoshiBalance } from '../../util/api-client';
 import { randomizeSatoshis } from '../../util/randomizeSats';
 import PencilIcon from '../../assets/edit-pencil';
 
 type QRCodeProps = BaseQRCodeProps & { renderAs: 'svg' };
-
-export type cryptoCurrency = 'BCH' | 'SAT' | 'bits' | 'XEC';
-export type currency = cryptoCurrency | fiatCurrency;
 
 export interface WidgetProps {
   to: string;

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -93,11 +93,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
 
     const addressDetails = useAddressDetails(address, active && !success);
 
-    const isFiat: boolean =
-      currency !== 'SAT' &&
-      currency !== 'BCH' &&
-      currency !== 'bits' &&
-      currency !== 'XEC';
+    const isFiat: boolean = currency !== 'BCH' && currency !== 'XEC';
 
     const getPrice = useCallback(async (): Promise<void> => {
       try {

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -4,7 +4,9 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import successSound from '../../assets/success.mp3.json';
 import { useAddressDetails } from '../../hooks/useAddressDetails';
 import {
-  fiatCurrency,
+  cryptoCurrency,
+  cryptoCurrencies,
+  currency,
   getFiatPrice,
   getSatoshiBalance,
   UnconfirmedTransaction,
@@ -16,9 +18,6 @@ import {
   currencyObject,
 } from '../../util/satoshis';
 import Widget, { WidgetProps } from './Widget';
-
-export type cryptoCurrency = 'BCH' | 'SAT' | 'bits' | 'XEC';
-export type currency = cryptoCurrency | fiatCurrency;
 
 export interface WidgetContainerProps
   extends Omit<Omit<WidgetProps, 'loading'>, 'success'> {
@@ -125,6 +124,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
         const receivedAmount = satoshisToBch(satoshis);
 
         if (!hideToasts)
+          // TODO: This assumes only bch
           enqueueSnackbar(`Received ${receivedAmount} BCH`, snackbarOptions);
 
         onTransaction?.(transaction, receivedAmount);
@@ -201,7 +201,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
     useEffect(() => {
       if (!active) return;
 
-      if (!props.amount || ['BCH', 'SAT', 'bits'].includes(currency)) {
+      if (!props.amount || cryptoCurrencies.includes(currency)) {
         setLoading(false);
       }
     }, [active, props.amount, currency]);

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -54,7 +54,7 @@ export const getFiatPrice = async (currency: currency): Promise<PriceData> => {
 
 export const getTransactionDetails = async (
   txid: string,
-  rootUrl = `https://api.paybutton.org`,
+  rootUrl = `https://api.paybutton.org`, // TODO: don't hardcode this url in
 ): Promise<TransactionDetails> => {
   const res = await fetch(`${rootUrl}/transactions/details/${txid}`);
   return await res.json();

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -33,6 +33,7 @@ export const getUTXOs = async (
 };
 
 export const getFiatPrice = async (currency: currency): Promise<PriceData> => {
+  // TODO: rename this. add another function for grabbing xec conversions
   const { data } = await axios.get(
     `https://markets.api.bitcoin.com/rates/convertor?c=BCH&q=${currency}`,
   );
@@ -67,7 +68,9 @@ export default {
 };
 
 export type fiatCurrency = 'USD' | 'CAD' | 'EUR' | 'GBP' | 'AUD';
+export const fiatCurrencies = ['USD', 'CAD', 'EUR', 'GBP', 'AUD'];
 export type cryptoCurrency = 'BCH' | 'SAT' | 'bits' | 'XEC';
+export const cryptoCurrencies = ['BCH', 'SAT', 'bits', 'XEC'];
 export type currency = cryptoCurrency | fiatCurrency;
 
 // export interface AddressDetails {

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -69,8 +69,8 @@ export default {
 
 export type fiatCurrency = 'USD' | 'CAD' | 'EUR' | 'GBP' | 'AUD';
 export const fiatCurrencies = ['USD', 'CAD', 'EUR', 'GBP', 'AUD'];
-export type cryptoCurrency = 'BCH' | 'SAT' | 'bits' | 'XEC';
-export const cryptoCurrencies = ['BCH', 'SAT', 'bits', 'XEC'];
+export type cryptoCurrency = 'BCH' | 'XEC';
+export const cryptoCurrencies = ['BCH', 'XEC'];
 export type currency = cryptoCurrency | fiatCurrency;
 
 // export interface AddressDetails {

--- a/react/src/util/satoshis.ts
+++ b/react/src/util/satoshis.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js';
-import { formatPrice, formatComma, formatBCH, formatBits } from './format';
+import { formatPrice, formatBCH } from './format';
 import { currency } from './api-client';
 
 const BCHdecimals = 8;
@@ -28,9 +28,6 @@ export const getCurrencyObject = (
   let BCHval = '';
   let satoshiVal = 0;
   const bchObj = new BigNumber(amount).decimalPlaces(BCHdecimals);
-  const inBCH = new BigNumber(amount)
-    .dividedBy(10 ** BCHdecimals)
-    .toFixed(BCHdecimals);
 
   const { c } = bchObj;
   // coefficient
@@ -38,12 +35,7 @@ export const getCurrencyObject = (
   // sign
 
   if (bchObj && c) {
-    if (currencyType === 'SAT') {
-      float = c[0];
-      string = formatComma(c[0]);
-      BCHval = inBCH;
-      satoshiVal = float;
-    } else if (currencyType === 'BCH') {
+    if (currencyType === 'BCH') {
       const satoshis = new BigNumber(`${amount}e+${BCHdecimals}`);
 
       if (satoshis !== null && satoshis.c !== null) {
@@ -52,16 +44,6 @@ export const getCurrencyObject = (
         string = formatBCH(string);
         BCHval = string;
         satoshiVal = satoshis.c[0];
-      }
-    } else if (currencyType === 'bits') {
-      const inBits = new BigNumber(amount).decimalPlaces(2).toFixed(2);
-
-      float = parseFloat(inBits);
-      string = formatBits(float);
-      BCHval = bchObj.dividedBy(1000000).toFixed(BCHdecimals);
-      const sat = bchObj.times(100);
-      if (sat.c !== null) {
-        satoshiVal = sat.c[0];
       }
     } else {
       float = amount;

--- a/react/src/util/satoshis.ts
+++ b/react/src/util/satoshis.ts
@@ -1,12 +1,9 @@
 import BigNumber from 'bignumber.js';
 import { formatPrice, formatComma, formatBCH, formatBits } from './format';
-import { fiatCurrency } from './api-client';
+import { currency } from './api-client';
 
 const BCHdecimals = 8;
 // const XECdecimals = 2;
-
-export type cryptoCurrency = 'BCH' | 'SAT' | 'bits' | 'XEC';
-export type currency = cryptoCurrency | fiatCurrency;
 
 export const satoshisToBch = (satoshis: number): number =>
   +(satoshis / 100_000_000).toFixed(8);


### PR DESCRIPTION
BCH functionality should remain intact - but `BITS` and `SATS` have been removed as currency types