### PR TITLE
Pass animation to widget component

### DIFF
--- a/react/src/components/Button/Button.tsx
+++ b/react/src/components/Button/Button.tsx
@@ -4,7 +4,7 @@ import React, { useRef, useState, useEffect } from 'react';
 
 import { Theme, ThemeName, useTheme } from '../../themes';
 
-type animation = 'slide' | 'invert' | 'none';
+export type animation = 'slide' | 'invert' | 'none';
 
 export interface ButtonProps {
   animation?: animation;

--- a/react/src/components/PayButton/PayButton.tsx
+++ b/react/src/components/PayButton/PayButton.tsx
@@ -102,6 +102,7 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
         to={to}
         amount={amount}
         currency={currency}
+        animation={animation}
         randomSatoshis={randomSatoshis}
         hideToasts={hideToasts}
         onTransaction={onTransaction}

--- a/react/src/components/PaymentDialog/PaymentDialog.tsx
+++ b/react/src/components/PaymentDialog/PaymentDialog.tsx
@@ -98,6 +98,7 @@ export const PaymentDialog = (
           to={to}
           amount={cleanAmount}
           currency={currency}
+          animation={animation}
           randomSatoshis={randomSatoshis}
           hideToasts={hideToasts}
           onSuccess={handleSuccess}

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -15,7 +15,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Theme, ThemeName, ThemeProvider, useTheme } from '../../themes';
 import { isValidCashAddress, isValidXecAddress } from '../../util/address';
 import { formatPrice } from '../../util/format';
-import Button from '../Button/Button';
+import { Button, animation } from '../Button/Button';
 import BarChart from '../BarChart/BarChart';
 
 import {
@@ -47,6 +47,7 @@ export interface WidgetProps {
   totalReceived?: number | null;
   goalAmount?: number | string | null;
   currency?: currency;
+  animation?: animation;
   currencyObject?: currencyObject | undefined;
   randomSatoshis?: boolean;
   price?: number;
@@ -124,6 +125,7 @@ export const Widget: React.FC<WidgetProps> = props => {
     goalAmount,
     ButtonComponent = Button,
     currency = 'BCH',
+    animation,
     randomSatoshis = true,
     currencyObject,
     editable,
@@ -552,6 +554,7 @@ export const Widget: React.FC<WidgetProps> = props => {
                 text={widgetButtonText}
                 onClick={handleButtonClick}
                 disabled={disabled}
+                animation={animation}
               />
             </Box>
           )}

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -69,6 +69,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
       active = true,
       to,
       currency = 'BCH',
+      animation,
       randomSatoshis = true,
       displayCurrency,
       hideToasts = false,
@@ -215,6 +216,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
           totalReceived={totalReceived}
           goalAmount={goalAmount}
           currency={currency}
+          animation={animation}
           currencyObject={currencyObj}
           loading={loading}
           randomSatoshis={randomSatoshis}


### PR DESCRIPTION
Passing the animation prop to the widget so it can be applied to the widget button. Before it wasn't getting through, so the widget button was always on 'slide'

Test plan: check the animation option is being properly applied to widget buttons 