### PR TITLE
Issue 152 - adding support for XEC - Actually add xec support

### DIFF
--- a/react/.env
+++ b/react/.env
@@ -1,3 +1,3 @@
 IMAGE_INLINE_SIZE_LIMIT=1000000
 REACT_APP_API_URL=https://api.paybutton.org
-REACT_APP_API_PRICING_URL=http://localhost:3000
+REACT_APP_API_PRICING_URL=https://api.paybutton.org

--- a/react/.env
+++ b/react/.env
@@ -1,2 +1,3 @@
 IMAGE_INLINE_SIZE_LIMIT=1000000
 REACT_APP_API_URL=https://api.paybutton.org
+REACT_APP_API_PRICING_URL=http://localhost:3000

--- a/react/src/components/PayButton/PayButton.tsx
+++ b/react/src/components/PayButton/PayButton.tsx
@@ -71,10 +71,8 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
       setHoverText(hoverTextDefault);
       setErrorMsg('Enter an address');
     } else if (isValidCashAddress(to)) {
-      setHoverText('Send BCH');
       setErrorMsg('');
     } else if (isValidXecAddress(to)) {
-      setHoverText('Send XEC');
       setErrorMsg('');
     } else {
       setHoverText(hoverTextDefault);

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -24,7 +24,7 @@ import BarChart from '../BarChart/BarChart';
 
 import { getCurrencyObject, currencyObject } from '../../util/satoshis';
 import { useAddressDetails } from '../../hooks/useAddressDetails';
-import { currency, getAddressBalance } from '../../util/api-client';
+import { currency, getAddressBalance, isFiat } from '../../util/api-client';
 import { randomizeSatoshis } from '../../util/randomizeSats';
 import PencilIcon from '../../assets/edit-pencil';
 
@@ -185,7 +185,6 @@ export const Widget: React.FC<WidgetProps> = props => {
   const query: string[] = [];
   const isMissingWidgetContainer = !totalReceived;
   const addressDetails = useAddressDetails(to, isMissingWidgetContainer);
-  const isFiat: boolean = currency !== 'BCH' && currency !== 'XEC';
   const hasPrice: boolean = price !== undefined && price > 0;
   let prefixedAddress: string;
 
@@ -300,7 +299,7 @@ export const Widget: React.FC<WidgetProps> = props => {
     } else {
       const notZeroValue: boolean =
         currencyObj?.float !== undefined && currencyObj.float > 0;
-      if (!isFiat && currencyObj && notZeroValue) {
+      if (!isFiat(currency) && currencyObj && notZeroValue) {
         const bchType: string = currencyObj.currency;
         setText(`Send ${currencyObj.string} ${bchType}`);
         query.push(`amount=${currencyObj.string}`);
@@ -380,7 +379,7 @@ export const Widget: React.FC<WidgetProps> = props => {
 
     const goal = getCurrencyObject(cleanGoalAmount, currency);
 
-    if (!isFiat) {
+    if (!isFiat(currency)) {
       if (goal !== undefined && progress.float > 0) {
         setGoalPercent((100 * progress.float) / goal.float);
         const string = progress.string;

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -271,17 +271,17 @@ export const Widget: React.FC<WidgetProps> = props => {
 
       if (isValidCashAddress(address)) {
         setText(
-          `Send ${currencyObj.string} ${currencyObj.currency} = ${bchAmount.BCHstring} BCH`,
+          `Send ${currencyObj.string} ${currencyObj.currency} = ${bchAmount.string} BCH`,
         );
         setWidgetButtonText(
-          `Send ${currencyObj.string} ${currencyObj.currency} = ${bchAmount.BCHstring} BCH`,
+          `Send ${currencyObj.string} ${currencyObj.currency} = ${bchAmount.string} BCH`,
         );
       } else if (isValidXecAddress(address)) {
         setText(
-          `Send ${currencyObj.string} ${currencyObj.currency} = ${bchAmount.BCHstring} XEC`,
+          `Send ${currencyObj.string} ${currencyObj.currency} = ${bchAmount.string} XEC`,
         );
         setWidgetButtonText(
-          `Send ${currencyObj.string} ${currencyObj.currency} = ${bchAmount.BCHstring} XEC`,
+          `Send ${currencyObj.string} ${currencyObj.currency} = ${bchAmount.string} XEC`,
         );
       }
       query.push(`amount=${bchAmount.float}`);
@@ -293,7 +293,7 @@ export const Widget: React.FC<WidgetProps> = props => {
       if (!isFiat && currencyObj && notZeroValue) {
         const bchType: string = currencyObj.currency;
         setText(`Send ${currencyObj.string} ${bchType}`);
-        query.push(`amount=${currencyObj.BCHstring}`);
+        query.push(`amount=${currencyObj.string}`);
         url = prefixedAddress + (query.length ? `?${query.join('&')}` : '');
         setUrl(url);
       } else {
@@ -374,7 +374,7 @@ export const Widget: React.FC<WidgetProps> = props => {
     if (!isFiat) {
       if (goal !== undefined && progress.float > 0) {
         setGoalPercent((100 * progress.float) / goal.float);
-        const string = progress.BCHstring!;
+        const string = progress.string;
         const truncated = parseFloat(string).toFixed(2);
         setGoalText(`${truncated} / ${cleanGoalAmount}`);
         setIsLoading(false);

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -262,15 +262,17 @@ export const Widget: React.FC<WidgetProps> = props => {
     }
     url = prefixedAddress + (query.length ? `?${query.join('&')}` : '');
 
+    let addressType: currency = 'AUD';
+
+    if (isValidCashAddress(address)) {
+      addressType = 'BCH';
+      setWidgetButtonText(`Send with BCH wallet`);
+    } else if (isValidXecAddress(address)) {
+      addressType = 'XEC';
+      setWidgetButtonText(`Send with XEC wallet`);
+    }
+
     if (currencyObj && hasPrice) {
-      let addressType: currency = 'AUD';
-
-      if (isValidCashAddress(address)) {
-        addressType = 'BCH';
-      } else if (isValidXecAddress(address)) {
-        addressType = 'XEC';
-      }
-
       const bchAmount = price
         ? getCurrencyObject(currencyObj.float / price, addressType)
         : null;
@@ -280,14 +282,8 @@ export const Widget: React.FC<WidgetProps> = props => {
           setText(
             `Send ${currencyObj.string} ${currencyObj.currency} = ${bchAmount.string} BCH`,
           );
-          setWidgetButtonText(
-            `Send ${currencyObj.string} ${currencyObj.currency} = ${bchAmount.string} BCH`,
-          );
         } else if (isValidXecAddress(address)) {
           setText(
-            `Send ${currencyObj.string} ${currencyObj.currency} = ${bchAmount.string} XEC`,
-          );
-          setWidgetButtonText(
             `Send ${currencyObj.string} ${currencyObj.currency} = ${bchAmount.string} XEC`,
           );
         }
@@ -308,10 +304,8 @@ export const Widget: React.FC<WidgetProps> = props => {
       } else {
         if (isValidCashAddress(address)) {
           setText(`Send any amount of BCH`);
-          setWidgetButtonText(`Send any amount of BCH`);
         } else if (isValidXecAddress(address)) {
           setText(`Send any amount of XEC`);
-          setWidgetButtonText(`Send any amount of XEC`);
         }
         url = prefixedAddress + (query.length ? `?${query.join('&')}` : '');
         setUrl(url);

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -16,7 +16,7 @@ import { Theme, ThemeName, ThemeProvider, useTheme } from '../../themes';
 import {
   isValidCashAddress,
   isValidXecAddress,
-  validCurrencyType,
+  getCurrencyTypeFromAddress,
 } from '../../util/address';
 import { formatPrice } from '../../util/format';
 import { Button, animation } from '../Button/Button';
@@ -121,8 +121,8 @@ export const Widget: React.FC<WidgetProps> = props => {
     totalReceived,
     goalAmount,
     ButtonComponent = Button,
+    currency = getCurrencyTypeFromAddress(to),
     animation,
-    currency = validCurrencyType(to),
     randomSatoshis = true,
     currencyObject,
     editable,
@@ -255,22 +255,18 @@ export const Widget: React.FC<WidgetProps> = props => {
     const address = to;
     let url;
 
-    if (isValidCashAddress(address)) {
-      prefixedAddress = `bitcoincash:${address.replace(/^.*:/, '')}`;
-    } else if (isValidXecAddress(address)) {
-      prefixedAddress = `ecash:${address.replace(/^.*:/, '')}`;
+    const addressType: currency = getCurrencyTypeFromAddress(address);
+    setWidgetButtonText(`Send with ${addressType} wallet`);
+
+    switch (addressType) {
+      case 'BCH':
+        prefixedAddress = `bitcoincash:${address.replace(/^.*:/, '')}`;
+        break;
+      case 'XEC':
+        prefixedAddress = `ecash:${address.replace(/^.*:/, '')}`;
+        break;
     }
     url = prefixedAddress + (query.length ? `?${query.join('&')}` : '');
-
-    let addressType: currency = 'AUD';
-
-    if (isValidCashAddress(address)) {
-      addressType = 'BCH';
-      setWidgetButtonText(`Send with BCH wallet`);
-    } else if (isValidXecAddress(address)) {
-      addressType = 'XEC';
-      setWidgetButtonText(`Send with XEC wallet`);
-    }
 
     if (currencyObj && hasPrice) {
       const bchAmount = price
@@ -278,15 +274,9 @@ export const Widget: React.FC<WidgetProps> = props => {
         : null;
 
       if (bchAmount) {
-        if (isValidCashAddress(address)) {
-          setText(
-            `Send ${currencyObj.string} ${currencyObj.currency} = ${bchAmount.string} BCH`,
-          );
-        } else if (isValidXecAddress(address)) {
-          setText(
-            `Send ${currencyObj.string} ${currencyObj.currency} = ${bchAmount.string} XEC`,
-          );
-        }
+        setText(
+          `Send ${currencyObj.string} ${currencyObj.currency} = ${bchAmount.string} ${addressType}`,
+        );
         query.push(`amount=${bchAmount.float}`);
       }
 
@@ -302,11 +292,7 @@ export const Widget: React.FC<WidgetProps> = props => {
         url = prefixedAddress + (query.length ? `?${query.join('&')}` : '');
         setUrl(url);
       } else {
-        if (isValidCashAddress(address)) {
-          setText(`Send any amount of BCH`);
-        } else if (isValidXecAddress(address)) {
-          setText(`Send any amount of XEC`);
-        }
+        setText(`Send any amount of ${addressType}`);
         url = prefixedAddress + (query.length ? `?${query.join('&')}` : '');
         setUrl(url);
       }

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -13,7 +13,11 @@ import QRCode, { BaseQRCodeProps } from 'qrcode.react';
 import React, { useEffect, useMemo, useState } from 'react';
 
 import { Theme, ThemeName, ThemeProvider, useTheme } from '../../themes';
-import { isValidCashAddress, isValidXecAddress } from '../../util/address';
+import {
+  isValidCashAddress,
+  isValidXecAddress,
+  validCurrencyType,
+} from '../../util/address';
 import { formatPrice } from '../../util/format';
 import { Button, animation } from '../Button/Button';
 import BarChart from '../BarChart/BarChart';
@@ -117,8 +121,8 @@ export const Widget: React.FC<WidgetProps> = props => {
     totalReceived,
     goalAmount,
     ButtonComponent = Button,
-    currency = 'BCH',
     animation,
+    currency = validCurrencyType(to),
     randomSatoshis = true,
     currencyObject,
     editable,
@@ -372,7 +376,6 @@ export const Widget: React.FC<WidgetProps> = props => {
   };
 
   useEffect(() => {
-    // const inSatoshis = getCurrencyObject(totalSatsReceived, 'SAT');
     const progress = getCurrencyObject(totalSatsReceived, currency);
 
     const goal = getCurrencyObject(cleanGoalAmount, currency);

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -101,7 +101,6 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
           setLoading(false);
           setPrice(price);
         } else if (isFiat(currency) && isValidXecAddress(address)) {
-          // TODO: THIS SHOULD POINT TO THE XEC FUNCTION. THIS IS TEMPORARY WHILE WAITING FOR BACKEND
           const data = await getXecFiatPrice(currency);
 
           const { price } = data;

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -6,7 +6,8 @@ import { useAddressDetails } from '../../hooks/useAddressDetails';
 import { isValidCashAddress, isValidXecAddress } from '../../util/address';
 import {
   cryptoCurrency,
-  cryptoCurrencies,
+  isCrypto,
+  isFiat,
   currency,
   getBchFiatPrice,
   getXecFiatPrice,
@@ -91,17 +92,15 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
 
     const addressDetails = useAddressDetails(address, active && !success);
 
-    const isFiat: boolean = currency !== 'BCH' && currency !== 'XEC';
-
     const getPrice = useCallback(async (): Promise<void> => {
       try {
-        if (isFiat && isValidCashAddress(address)) {
+        if (isFiat(currency) && isValidCashAddress(address)) {
           const data = await getBchFiatPrice(currency);
 
           const { price } = data;
           setLoading(false);
           setPrice(price);
-        } else if (isFiat && isValidXecAddress(address)) {
+        } else if (isFiat(currency) && isValidXecAddress(address)) {
           // TODO: THIS SHOULD POINT TO THE XEC FUNCTION. THIS IS TEMPORARY WHILE WAITING FOR BACKEND
           const data = await getXecFiatPrice(currency);
 
@@ -182,7 +181,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
         setCurrencyObj(obj);
       }
 
-      if (isFiat && price === 0) {
+      if (isFiat(currency) && price === 0) {
         getPrice();
       }
     }, []);
@@ -203,7 +202,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
     useEffect(() => {
       if (!active) return;
 
-      if (!props.amount || cryptoCurrencies.includes(currency)) {
+      if (!props.amount || isCrypto(currency)) {
         setLoading(false);
       }
     }, [active, props.amount, currency]);

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -3,7 +3,11 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import successSound from '../../assets/success.mp3.json';
 import { useAddressDetails } from '../../hooks/useAddressDetails';
-import { isValidCashAddress, isValidXecAddress } from '../../util/address';
+import {
+  isValidCashAddress,
+  isValidXecAddress,
+  getCurrencyTypeFromAddress,
+} from '../../util/address';
 import {
   cryptoCurrency,
   isCrypto,
@@ -123,9 +127,14 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
 
         const receivedAmount = satoshis;
 
+        const currencyTicker = getCurrencyTypeFromAddress(to);
+
         if (!hideToasts)
           // TODO: This assumes only bch
-          enqueueSnackbar(`Received ${receivedAmount} BCH`, snackbarOptions);
+          enqueueSnackbar(
+            `Received ${receivedAmount} ${currencyTicker}`,
+            snackbarOptions,
+          );
 
         onTransaction?.(transaction, receivedAmount);
 
@@ -148,7 +157,15 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
       const split = string.split(':')[1];
 
       if (split === undefined) {
-        string = `bitcoincash:${string}`;
+        const currencyTicker = getCurrencyTypeFromAddress(to);
+        switch (currencyTicker) {
+          case 'BCH':
+            string = `bitcoincash:${string}`;
+            break;
+          case 'XEC':
+            string = `ecash:${string}`;
+            break;
+        }
       }
       return string;
     };

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -10,15 +10,10 @@ import {
   currency,
   getBchFiatPrice,
   getXecFiatPrice,
-  getSatoshiBalance,
+  getAddressBalance,
   UnconfirmedTransaction,
 } from '../../util/api-client';
-import {
-  bchToSatoshis,
-  satoshisToBch,
-  getCurrencyObject,
-  currencyObject,
-} from '../../util/satoshis';
+import { getCurrencyObject, currencyObject } from '../../util/satoshis';
 import Widget, { WidgetProps } from './Widget';
 
 export interface WidgetContainerProps
@@ -128,7 +123,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
       (transaction: any, satoshis: number) => {
         if (sound && !hideToasts) txSound.play().catch(() => {});
 
-        const receivedAmount = satoshisToBch(satoshis);
+        const receivedAmount = satoshis;
 
         if (!hideToasts)
           // TODO: This assumes only bch
@@ -136,7 +131,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
 
         onTransaction?.(transaction, receivedAmount);
 
-        if (amount && satoshis === bchToSatoshis(amount)) {
+        if (amount && satoshis === amount) {
           setSuccess(true);
           onSuccess?.(transaction, receivedAmount);
         }
@@ -195,8 +190,8 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
     useEffect(() => {
       (async (): Promise<void> => {
         if (addressDetails) {
-          const { satoshis } = await getSatoshiBalance(address);
-          setTotalReceived(satoshis);
+          const { balance } = await getAddressBalance(address);
+          setTotalReceived(balance);
         }
       })();
 

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -3,11 +3,13 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import successSound from '../../assets/success.mp3.json';
 import { useAddressDetails } from '../../hooks/useAddressDetails';
+import { isValidCashAddress, isValidXecAddress } from '../../util/address';
 import {
   cryptoCurrency,
   cryptoCurrencies,
   currency,
-  getFiatPrice,
+  getBchFiatPrice,
+  getXecFiatPrice,
   getSatoshiBalance,
   UnconfirmedTransaction,
 } from '../../util/api-client';
@@ -98,8 +100,16 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
 
     const getPrice = useCallback(async (): Promise<void> => {
       try {
-        if (isFiat) {
-          const data = await getFiatPrice(currency);
+        if (isFiat && isValidCashAddress(address)) {
+          const data = await getBchFiatPrice(currency);
+
+          const { price } = data;
+          setLoading(false);
+          setPrice(price);
+        } else if (isFiat && isValidXecAddress(address)) {
+          // TODO: THIS SHOULD POINT TO THE XEC FUNCTION. THIS IS TEMPORARY WHILE WAITING FOR BACKEND
+          const data = await getXecFiatPrice(currency);
+
           const { price } = data;
           setLoading(false);
           setPrice(price);

--- a/react/src/util/address.ts
+++ b/react/src/util/address.ts
@@ -29,7 +29,7 @@ export const getCurrencyTypeFromAddress = (address: string): currency => {
   } else if (isValidXecAddress(address)) {
     return 'XEC';
   } else {
-    throw new Error();
+    throw new Error('Invalid currency');
   }
 };
 

--- a/react/src/util/address.ts
+++ b/react/src/util/address.ts
@@ -23,18 +23,18 @@ export const isValidXecAddress = (address: string): boolean => {
   }
 };
 
-export const validCurrencyType = (address: string): currency => {
+export const getCurrencyTypeFromAddress = (address: string): currency => {
   if (isValidCashAddress(address)) {
     return 'BCH';
   } else if (isValidXecAddress(address)) {
     return 'XEC';
   } else {
-    return 'GBP';
+    throw new Error();
   }
 };
 
 export default {
   isValidCashAddress,
   isValidXecAddress,
-  validCurrencyType,
+  getCurrencyTypeFromAddress,
 };

--- a/react/src/util/address.ts
+++ b/react/src/util/address.ts
@@ -1,4 +1,5 @@
 import * as xecaddr from 'xecaddrjs';
+import { currency } from '../util/api-client';
 
 export const isValidCashAddress = (address: string): boolean => {
   if (!address) return false;
@@ -22,7 +23,18 @@ export const isValidXecAddress = (address: string): boolean => {
   }
 };
 
+export const validCurrencyType = (address: string): currency => {
+  if (isValidCashAddress(address)) {
+    return 'BCH';
+  } else if (isValidXecAddress(address)) {
+    return 'XEC';
+  } else {
+    return 'GBP';
+  }
+};
+
 export default {
   isValidCashAddress,
   isValidXecAddress,
+  validCurrencyType,
 };

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -105,6 +105,7 @@ export type currency = cryptoCurrency | fiatCurrency;
 
 export function isFiat(unknownString: string): unknownString is fiatCurrency {
   return fiatCurrencies.includes(unknownString as fiatCurrency);
+  // this is a comment
 }
 
 export function isCrypto(

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -93,11 +93,25 @@ export default {
   getAddressBalance,
 };
 
-export type fiatCurrency = 'USD' | 'CAD' | 'EUR' | 'GBP' | 'AUD';
-export const fiatCurrencies = ['USD', 'CAD', 'EUR', 'GBP', 'AUD'];
-export type cryptoCurrency = 'BCH' | 'XEC';
-export const cryptoCurrencies = ['BCH', 'XEC'];
+export const fiatCurrencies = ['USD', 'CAD', 'EUR', 'GBP', 'AUD'] as const;
+type fiatCurrenciesTuple = typeof fiatCurrencies; // readonly ['USD', 'CAD', 'EUR', 'GBP', 'AUD']
+export type fiatCurrency = fiatCurrenciesTuple[number]; // "USD" | "CAD" | "EUR" | "GBP" | "AUD"
+
+export const cryptoCurrencies = ['BCH', 'XEC'] as const;
+type cryptoCurrenciesTuple = typeof cryptoCurrencies; // readonly ['BCH', 'XEC']
+export type cryptoCurrency = cryptoCurrenciesTuple[number]; // "BCH" | "XEC"
+
 export type currency = cryptoCurrency | fiatCurrency;
+
+export function isFiat(unknownString: string): unknownString is fiatCurrency {
+  return fiatCurrencies.includes(unknownString as fiatCurrency);
+}
+
+export function isCrypto(
+  unknownString: string,
+): unknownString is cryptoCurrency {
+  return cryptoCurrencies.includes(unknownString as cryptoCurrency);
+}
 
 // export interface AddressDetails {
 //   balance: number;

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -94,7 +94,6 @@ export type currency = cryptoCurrency | fiatCurrency;
 
 export function isFiat(unknownString: string): unknownString is fiatCurrency {
   return fiatCurrencies.includes(unknownString as fiatCurrency);
-  // this is a comment
 }
 
 export function isCrypto(

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -57,6 +57,33 @@ export const getXecFiatPrice = async (
   return { price };
 };
 
+export const getFiatPrice = async (
+  fiat: fiatCurrency,
+  crypto: cryptoCurrency,
+  rootUrl = process.env.REACT_APP_API_PRICING_URL,
+): Promise<PriceData> => {
+  // TODO: get rid of 'getXecFiatPrice' && 'getBchFiatPrice' and replace
+  // with this function.
+  let url = '';
+
+  switch (crypto) {
+    case 'BCH':
+      url = `${rootUrl}/price/bitcoincash/${_.lowerCase(fiat)}`;
+      break;
+    case 'XEC':
+      url = `${rootUrl}/price/ecash/${_.lowerCase(fiat)}`;
+      break;
+  }
+  if (!url) {
+    throw new Error();
+  } else {
+    const { data } = await axios.get(url);
+
+    const price: number = data;
+    return { price };
+  }
+};
+
 // export const getTransactionDetails = async (
 //   txid: string,
 // ): Promise<TransactionDetails> => {

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import _ from 'lodash';
 
 // export const getAddressDetails = async (
 //   address: string,
@@ -34,37 +35,25 @@ export const getUTXOs = async (
 
 export const getBchFiatPrice = async (
   currency: currency,
+  rootUrl = process.env.REACT_APP_API_PRICING_URL,
 ): Promise<PriceData> => {
-  // TODO: rename this. add another function for grabbing xec conversions
   const { data } = await axios.get(
-    `https://markets.api.bitcoin.com/rates/convertor?c=BCH&q=${currency}`,
+    `${rootUrl}/price/bitcoincash/${_.lowerCase(currency)}`,
   );
 
-  const { rate } = data[currency];
-  const price: number = rate;
+  const price: number = data;
   return { price };
 };
 
 export const getXecFiatPrice = async (
   currency: currency,
+  rootUrl = process.env.REACT_APP_API_PRICING_URL,
 ): Promise<PriceData> => {
-  // TODO: Actually add a xec endpoint to get live data from
-
   const { data } = await axios.get(
-    `https://markets.api.bitcoin.com/rates/convertor?c=BCH&q=${currency}`,
+    `${rootUrl}/price/ecash/${_.lowerCase(currency)}`,
   );
 
-  if (!currency) {
-    // TODO: remove this ifstatement. waiting on a way to get xec price
-    // this is a do nothing if statement to prevent ts complaining about not using currency
-    console.log(currency);
-    console.log(data);
-  }
-
-  // 0.00002894 xec price in usd on nov 29 2022
-  // const { rate } = data[currency];
-  // const price: number = Math.round(rate * 100);
-  const price = 0.00002894;
+  const price: number = data;
   return { price };
 };
 

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -32,7 +32,9 @@ export const getUTXOs = async (
   return await res.json();
 };
 
-export const getFiatPrice = async (currency: currency): Promise<PriceData> => {
+export const getBchFiatPrice = async (
+  currency: currency,
+): Promise<PriceData> => {
   // TODO: rename this. add another function for grabbing xec conversions
   const { data } = await axios.get(
     `https://markets.api.bitcoin.com/rates/convertor?c=BCH&q=${currency}`,
@@ -40,6 +42,29 @@ export const getFiatPrice = async (currency: currency): Promise<PriceData> => {
 
   const { rate } = data[currency];
   const price: number = Math.round(rate * 100);
+  return { price };
+};
+
+export const getXecFiatPrice = async (
+  currency: currency,
+): Promise<PriceData> => {
+  // TODO: Actually add a xec endpoint to get live data from
+
+  const { data } = await axios.get(
+    `https://markets.api.bitcoin.com/rates/convertor?c=BCH&q=${currency}`,
+  );
+
+  if (!currency) {
+    // this is a do nothing if statement to prevent ts complaining about not using currency
+    console.log(currency);
+    console.log(data);
+  }
+
+  // 0.00002894 xec price in usd on nov 29 2022
+  // const { rate } = data[currency];
+  // const price: number = Math.round(rate * 100);
+  const price = 0.00002894;
+  console.log(price);
   return { price };
 };
 
@@ -63,7 +88,8 @@ export const getTransactionDetails = async (
 export default {
   getAddressDetails,
   getTransactionDetails,
-  getFiatPrice,
+  getBchFiatPrice,
+  getXecFiatPrice,
   getSatoshiBalance,
 };
 

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -75,7 +75,7 @@ export const getFiatPrice = async (
       break;
   }
   if (!url) {
-    throw new Error();
+    throw new Error('No url');
   } else {
     const { data } = await axios.get(url);
 

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -16,10 +16,10 @@ export const getAddressDetails = async (
   return await res.json();
 };
 
-export const getSatoshiBalance = async (
+export const getAddressBalance = async (
   address: string,
   rootUrl = process.env.REACT_APP_API_URL,
-): Promise<{ satoshis: number }> => {
+): Promise<{ balance: number }> => {
   const res = await fetch(`${rootUrl}/address/balance/${address}`);
   return await res.json();
 };
@@ -41,7 +41,7 @@ export const getBchFiatPrice = async (
   );
 
   const { rate } = data[currency];
-  const price: number = Math.round(rate * 100);
+  const price: number = rate;
   return { price };
 };
 
@@ -90,7 +90,7 @@ export default {
   getTransactionDetails,
   getBchFiatPrice,
   getXecFiatPrice,
-  getSatoshiBalance,
+  getAddressBalance,
 };
 
 export type fiatCurrency = 'USD' | 'CAD' | 'EUR' | 'GBP' | 'AUD';

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -55,6 +55,7 @@ export const getXecFiatPrice = async (
   );
 
   if (!currency) {
+    // TODO: remove this ifstatement. waiting on a way to get xec price
     // this is a do nothing if statement to prevent ts complaining about not using currency
     console.log(currency);
     console.log(data);
@@ -64,7 +65,6 @@ export const getXecFiatPrice = async (
   // const { rate } = data[currency];
   // const price: number = Math.round(rate * 100);
   const price = 0.00002894;
-  console.log(price);
   return { price };
 };
 

--- a/react/src/util/format.ts
+++ b/react/src/util/format.ts
@@ -69,8 +69,8 @@ export const formatBCH = (bch: string) => {
   return formattedString;
 };
 
-export const formatBits = (bits: string | number) => {
-  const val = +bits;
+export const formatXEC = (xec: string) => {
+  const val = +xec;
   const formattedString = currencyFormat.format(val, {
     symbol: '',
     decimal: '.',
@@ -87,5 +87,5 @@ export default {
   formatPrice,
   formatComma,
   formatBCH,
-  formatBits,
+  formatXEC,
 };

--- a/react/src/util/satoshis.ts
+++ b/react/src/util/satoshis.ts
@@ -2,8 +2,8 @@ import BigNumber from 'bignumber.js';
 import { formatPrice, formatBCH, formatXEC } from './format';
 import { currency } from './api-client';
 
-const BCHdecimals = 8;
-const XECdecimals = 2;
+const BCH_DECIMALS = 8;
+const XEC_DECIMALS = 2;
 
 export type currencyObject = {
   float: number;
@@ -22,16 +22,16 @@ export const getCurrencyObject = (
     const primaryUnit = new BigNumber(`${amount}`);
 
     if (primaryUnit !== null && primaryUnit.c !== null) {
-      float = parseFloat(new BigNumber(primaryUnit).toFixed(BCHdecimals));
-      string = new BigNumber(`${primaryUnit}`).toFixed(BCHdecimals);
+      float = parseFloat(new BigNumber(primaryUnit).toFixed(BCH_DECIMALS));
+      string = new BigNumber(`${primaryUnit}`).toFixed(BCH_DECIMALS);
       string = formatBCH(string);
     }
   } else if (currencyType === 'XEC') {
     const primaryUnit = new BigNumber(`${amount}`);
 
     if (primaryUnit !== null && primaryUnit.c !== null) {
-      float = parseFloat(new BigNumber(primaryUnit).toFixed(XECdecimals));
-      string = new BigNumber(`${primaryUnit}`).toFixed(XECdecimals);
+      float = parseFloat(new BigNumber(primaryUnit).toFixed(XEC_DECIMALS));
+      string = new BigNumber(`${primaryUnit}`).toFixed(XEC_DECIMALS);
       string = formatXEC(string);
     }
   } else {

--- a/react/src/util/satoshis.ts
+++ b/react/src/util/satoshis.ts
@@ -1,22 +1,14 @@
 import BigNumber from 'bignumber.js';
-import { formatPrice, formatBCH } from './format';
+import { formatPrice, formatBCH, formatXEC } from './format';
 import { currency } from './api-client';
 
 const BCHdecimals = 8;
-// const XECdecimals = 2;
-
-export const satoshisToBch = (satoshis: number): number =>
-  +(satoshis / 100_000_000).toFixed(8);
-
-export const bchToSatoshis = (bch: number): number =>
-  Math.round(bch * 100_000_000);
+const XECdecimals = 2;
 
 export type currencyObject = {
   float: number;
   string: string;
   currency: string;
-  BCHstring?: string | undefined;
-  satoshis?: number | undefined;
 };
 
 export const getCurrencyObject = (
@@ -25,43 +17,33 @@ export const getCurrencyObject = (
 ): currencyObject => {
   let string = '';
   let float = 0;
-  let BCHval = '';
-  let satoshiVal = 0;
-  const bchObj = new BigNumber(amount).decimalPlaces(BCHdecimals);
 
-  const { c } = bchObj;
-  // coefficient
-  // exponent
-  // sign
+  if (currencyType === 'BCH') {
+    const primaryUnit = new BigNumber(`${amount}`);
 
-  if (bchObj && c) {
-    if (currencyType === 'BCH') {
-      const satoshis = new BigNumber(`${amount}e+${BCHdecimals}`);
-
-      if (satoshis !== null && satoshis.c !== null) {
-        float = toBCH(satoshis.c[0]);
-        string = new BigNumber(`${satoshis.c[0]}e-8`).toPrecision();
-        string = formatBCH(string);
-        BCHval = string;
-        satoshiVal = satoshis.c[0];
-      }
-    } else {
-      float = amount;
-      string = formatPrice(amount, currencyType, 2);
+    if (primaryUnit !== null && primaryUnit.c !== null) {
+      float = parseFloat(new BigNumber(primaryUnit).toFixed(BCHdecimals));
+      string = new BigNumber(`${primaryUnit}`).toFixed(BCHdecimals);
+      string = formatBCH(string);
     }
+  } else if (currencyType === 'XEC') {
+    const primaryUnit = new BigNumber(`${amount}`);
+
+    if (primaryUnit !== null && primaryUnit.c !== null) {
+      float = parseFloat(new BigNumber(primaryUnit).toFixed(XECdecimals));
+      string = new BigNumber(`${primaryUnit}`).toFixed(XECdecimals);
+      string = formatXEC(string);
+    }
+  } else {
+    float = amount;
+    string = formatPrice(amount, currencyType, 2);
   }
+
   return {
     float: float,
     string,
     currency: currencyType,
-    BCHstring: BCHval,
-    satoshis: satoshiVal,
   };
-};
-
-const toBCH = (amount: number) => {
-  const num = new BigNumber(amount).dividedBy(10 ** 8).toFixed(8);
-  return parseFloat(num);
 };
 
 // future token functions
@@ -83,7 +65,5 @@ const toBCH = (amount: number) => {
 // };
 
 export default {
-  satoshisToBch,
-  bchToSatoshis,
   getCurrencyObject,
 };


### PR DESCRIPTION
This branch actually adds XEC support. Additionally, it (hopefully) finishes the job of converting all calculations to primary units instead of doing calculations in satoshis

Using a XEC address should change the theme, the QR, button text, etc. Selecting a fiat currency and goal should give the proper XEC and BCH amounts. 