### PR TITLE
Fix paymentDialogs build error

### DIFF
--- a/react/src/components/PaymentDialog/PaymentDialog.tsx
+++ b/react/src/components/PaymentDialog/PaymentDialog.tsx
@@ -3,8 +3,9 @@ import React, { useState, useEffect } from 'react';
 
 import { Theme, ThemeName, ThemeProvider, useTheme } from '../../themes';
 import Button, { ButtonProps } from '../Button/Button';
-import { WidgetContainer, currency } from '../Widget/WidgetContainer';
+import { WidgetContainer } from '../Widget/WidgetContainer';
 import { isValidCashAddress, isValidXecAddress } from '../../util/address';
+import { currency } from '../../util/api-client';
 
 export interface PaymentDialogProps extends ButtonProps {
   to: string;


### PR DESCRIPTION
`currency` was being imported from the wrong file, presumably it just wasn't caught in the `currency` refactor. This was causing a failure to `npm run build` in the react folder.

Test Plan:
- run `npm run build && npm start` in the react folder. The project and storybook should build.
- Everything related to `currency` should work fine in the `paymentDialog` section on storybook