### PR TITLE
[Issue #151] fix: transaction api called twice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.env.local

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -41,7 +41,6 @@ export interface WidgetProps {
   theme?: ThemeName | Theme;
   foot?: React.ReactNode;
   disabled: boolean;
-  totalReceived?: number | null;
   goalAmount?: number | string | null;
   currency?: currency;
   animation?: animation;
@@ -119,7 +118,6 @@ export const Widget: React.FC<WidgetProps> = props => {
     loading,
     success,
     successText,
-    totalReceived,
     goalAmount,
     ButtonComponent = Button,
     currency = getCurrencyTypeFromAddress(to),
@@ -185,24 +183,19 @@ export const Widget: React.FC<WidgetProps> = props => {
   }, [recentlyCopied]);
 
   const query: string[] = [];
-  const isMissingWidgetContainer = !totalReceived;
-  const addressDetails = useAddressDetails(to, isMissingWidgetContainer);
+  const addressDetails = useAddressDetails(to);
   const hasPrice: boolean = price !== undefined && price > 0;
   let prefixedAddress: string;
 
   useEffect(() => {
-    if (totalReceived) {
-      return setTotalSatsReceived(totalReceived);
-    }
-
     (async (): Promise<void> => {
       if (addressDetails) {
         if (setAddressDetails) setAddressDetails(addressDetails); // update parent component
-        const { balance } = await getAddressBalance(to);
-        setTotalSatsReceived(balance);
+        const balance = await getAddressBalance(to);
+        if (balance) setTotalSatsReceived(balance);
       }
     })();
-  }, [addressDetails, totalReceived, totalSatsReceived]);
+  }, [addressDetails]);
 
   useEffect(() => {
     const invalidAmount = amount !== undefined && amount && isNaN(+amount);

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -49,6 +49,7 @@ export interface WidgetProps {
   randomSatoshis?: boolean;
   price?: number;
   editable?: boolean;
+  setAddressDetails?: any; // function parent WidgetContainer passes down to be updated
 }
 
 interface StyleProps {
@@ -126,6 +127,7 @@ export const Widget: React.FC<WidgetProps> = props => {
     randomSatoshis = true,
     currencyObject,
     editable,
+    setAddressDetails,
   } = Object.assign({}, Widget.defaultProps, props);
 
   const theme = useTheme(props.theme, isValidXecAddress(to));
@@ -195,6 +197,7 @@ export const Widget: React.FC<WidgetProps> = props => {
 
     (async (): Promise<void> => {
       if (addressDetails) {
+        if (setAddressDetails) setAddressDetails(addressDetails); // update parent component
         const { balance } = await getAddressBalance(to);
         setTotalSatsReceived(balance);
       }

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -94,7 +94,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
     const [amount, setAmount] = useState(props.amount);
     const [price, setPrice] = useState(0);
 
-    const addressDetails = useAddressDetails(address, active && !success);
+    const [addressDetails, setAddressDetails] = useState(null);
 
     const getPrice = useCallback(async (): Promise<void> => {
       try {
@@ -240,6 +240,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
           success={success}
           disabled={disabled}
           editable={editable}
+          setAddressDetails={setAddressDetails}
         />
       </React.Fragment>
     );

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -15,7 +15,6 @@ import {
   currency,
   getBchFiatPrice,
   getXecFiatPrice,
-  getAddressBalance,
   UnconfirmedTransaction,
 } from '../../util/api-client';
 import { getCurrencyObject, currencyObject } from '../../util/satoshis';
@@ -87,7 +86,6 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
 
     const [success, setSuccess] = useState(false);
     const { enqueueSnackbar } = useSnackbar();
-    const [totalReceived, setTotalReceived] = useState(0);
     const [currencyObj, setCurrencyObj] = useState<currencyObject>();
 
     const [loading, setLoading] = useState(true);
@@ -205,13 +203,6 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
     }, []);
 
     useEffect(() => {
-      (async (): Promise<void> => {
-        if (addressDetails) {
-          const { balance } = await getAddressBalance(address);
-          setTotalReceived(balance);
-        }
-      })();
-
       addressDetails?.unconfirmedTransactionsList?.map(unconfirmed => {
         handleNewTransaction(unconfirmed);
       });
@@ -231,7 +222,6 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
           to={to}
           {...widgetProps}
           amount={amount}
-          totalReceived={totalReceived}
           goalAmount={goalAmount}
           currency={currency}
           animation={animation}

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -2,7 +2,6 @@ import { OptionsObject, SnackbarProvider, useSnackbar } from 'notistack';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import successSound from '../../assets/success.mp3.json';
-import { useAddressDetails } from '../../hooks/useAddressDetails';
 import {
   isValidCashAddress,
   isValidXecAddress,

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -8,6 +8,7 @@ import {
   getCurrencyTypeFromAddress,
 } from '../../util/address';
 import {
+  AddressDetails,
   cryptoCurrency,
   isCrypto,
   isFiat,
@@ -93,7 +94,9 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
     const [amount, setAmount] = useState(props.amount);
     const [price, setPrice] = useState(0);
 
-    const [addressDetails, setAddressDetails] = useState(null);
+    const [addressDetails, setAddressDetails] = useState<
+      AddressDetails | undefined
+    >();
 
     const getPrice = useCallback(async (): Promise<void> => {
       try {

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -7,22 +7,22 @@ import _ from 'lodash';
 //   const res = await fetch(
 //     `https://rest.bitcoin.com/v2/address/details/${address}`,
 //   );
-//   return await res.json();
+//   return res.json();
 // };
 export const getAddressDetails = async (
   address: string,
   rootUrl = process.env.REACT_APP_API_URL,
 ): Promise<AddressDetails> => {
   const res = await fetch(`${rootUrl}/address/transactions/${address}`);
-  return await res.json();
+  return res.json();
 };
 
 export const getAddressBalance = async (
   address: string,
   rootUrl = process.env.REACT_APP_API_URL,
-): Promise<{ balance: number }> => {
-  const res = await fetch(`${rootUrl}/address/balance/${address}`);
-  return await res.json();
+): Promise<number> => {
+  const res = await axios.get(`${rootUrl}/address/balance/${address}`);
+  return isNaN(res.data) ? null : res.data;
 };
 
 export const getUTXOs = async (
@@ -30,7 +30,7 @@ export const getUTXOs = async (
   rootUrl = process.env.REACT_APP_API_URL,
 ): Promise<UtxoDetails> => {
   const res = await fetch(`${rootUrl}/address/utxo/${address}`);
-  return await res.json();
+  return res.json();
 };
 
 export const getBchFiatPrice = async (
@@ -90,15 +90,15 @@ export const getFiatPrice = async (
 //   const res = await fetch(
 //     `https://rest.bitcoin.com/v2/transaction/details/${txid}`,
 //   );
-//   return await res.json();
+//   return res.json();
 // };
 
 export const getTransactionDetails = async (
   txid: string,
-  rootUrl = `https://api.paybutton.org`, // TODO: don't hardcode this url in
+  rootUrl = process.env.REACT_APP_API_URL,
 ): Promise<TransactionDetails> => {
   const res = await fetch(`${rootUrl}/transactions/details/${txid}`);
-  return await res.json();
+  return res.json();
 };
 
 export default {


### PR DESCRIPTION
Description:

When opening the network tab and opening the qrcode Widget either by:
 1. clicking on any child of the menu on the left `Paybutton` and then clicking on the button on the right
 2. clicking on any child of the menu on the left `Widget`
You can see that, after 3 seconds, requests for the transactions endpoint were made in duplicate before this PR, on this branch this is solved and only 1 request is made each time.

Test plan:

Described above.

We were creating the hook `useAddressDetails` twice, once in the parent `WidgetContainer` and again in the child `Widget`, since we have a page with the child and not the parent (2.) and another one with both (1.), I made an optional parameter when creating the child that allows the child only to have this hook and update the parent (if parent needs it).