### PR TITLE
[Issue #214] fix: use float to avoid comma related issues when parsing to float to…

### DIFF
--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -360,7 +360,7 @@ export const Widget: React.FC<WidgetProps> = props => {
         setGoalPercent((100 * progress.float) / goal.float);
         const string = progress.string;
         const truncated = parseFloat(string).toFixed(2);
-        setGoalText(`${truncated} / ${cleanGoalAmount}`);
+        setGoalText(`${progress.float} / ${cleanGoalAmount}`);
         setIsLoading(false);
       }
     } else {

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -358,8 +358,6 @@ export const Widget: React.FC<WidgetProps> = props => {
     if (!isFiat(currency)) {
       if (goal !== undefined && progress.float > 0) {
         setGoalPercent((100 * progress.float) / goal.float);
-        const string = progress.string;
-        const truncated = parseFloat(string).toFixed(2);
         setGoalText(`${progress.float} / ${cleanGoalAmount}`);
         setIsLoading(false);
       }


### PR DESCRIPTION
<!-- Insert the related issue below -->
Related to #214 
---
- [X] Solves


<!-- Non-technical, objective summary of what the PR accomplishes -->
Description
---
Fixes amount in wallet for XEC. It was 1000 times less than it should.
Before:
![image](https://github.com/PayButton/paybutton/assets/21281174/a1f8ca13-a34d-49f2-bb45-2a12bf899430)

After:
![image](https://github.com/PayButton/paybutton/assets/21281174/66fba9bc-57fc-4f12-984b-b5c66081138d)




Test plan
---
Make a button e.g.
```
  <div class="paybutton" to="ecash:qpwelztp2gcan5q8vla2fqhr94p5rvvm55aqk86fhr" goal-amount="12000" amount="100" currency="XEC" text="Purchase"></div>
```
Doesn't matter if HTML or javascript.  The before and after should follow as the example above.



 
Remarks
---
This is vunerable to float precision issues, tho maybe its unlikely because we truncate it afterwards. In any case, we shouldn't worry about that after #216 which I'll do next.
