### PR TITLE
[Issue #218] fix: toast when payment received

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,13 @@
-<!-- Insert the related issue below -->
 Related to #
----
-- [ ] Solves
-- [ ] Partially solves
 
-
-<!-- Remove this section if there are no dependencies -->
+<!--
 Depends on
 ---
 - [ ] #
+-->
 
 
-<!-- Non-technical, objective summary of what the PR accomplishes -->
+<!-- Non-technical -->
 Description
 ---
 

--- a/react/src/components/PayButton/PayButton.tsx
+++ b/react/src/components/PayButton/PayButton.tsx
@@ -5,6 +5,7 @@ import Button, { ButtonProps } from '../Button/Button';
 import { currency } from '../../util/api-client';
 import { PaymentDialog } from '../PaymentDialog/PaymentDialog';
 import { isValidCashAddress, isValidXecAddress } from '../../util/address';
+import BigNumber from 'bignumber.js';
 
 export interface PayButtonProps extends ButtonProps {
   to: string;
@@ -20,8 +21,8 @@ export interface PayButtonProps extends ButtonProps {
   goalAmount?: number | string;
   disableEnforceFocus?: boolean;
   editable?: boolean;
-  onSuccess?: (txid: string, amount: number) => void;
-  onTransaction?: (txid: string, amount: number) => void;
+  onSuccess?: (txid: string, amount: BigNumber) => void;
+  onTransaction?: (txid: string, amount: BigNumber) => void;
 }
 
 export const PayButton = (props: PayButtonProps): React.ReactElement => {

--- a/react/src/components/PaymentDialog/PaymentDialog.tsx
+++ b/react/src/components/PaymentDialog/PaymentDialog.tsx
@@ -6,6 +6,7 @@ import Button, { ButtonProps } from '../Button/Button';
 import { WidgetContainer } from '../Widget/WidgetContainer';
 import { isValidCashAddress, isValidXecAddress } from '../../util/address';
 import { currency } from '../../util/api-client';
+import BigNumber from 'bignumber.js';
 
 export interface PaymentDialogProps extends ButtonProps {
   to: string;
@@ -23,8 +24,8 @@ export interface PaymentDialogProps extends ButtonProps {
   active?: boolean;
   container?: HTMLElement;
   onClose?: () => void;
-  onSuccess?: (txid: string, amount: number) => void;
-  onTransaction?: (txid: string, amount: number) => void;
+  onSuccess?: (txid: string, amount: BigNumber) => void;
+  onTransaction?: (txid: string, amount: BigNumber) => void;
 }
 
 export const PaymentDialog = (
@@ -55,7 +56,7 @@ export const PaymentDialog = (
     setSuccess(false);
     if (onClose) onClose();
   };
-  const handleSuccess = (txid: string, amount: number): void => {
+  const handleSuccess = (txid: string, amount: BigNumber): void => {
     setSuccess(true);
     onSuccess?.(txid, amount);
   };

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -157,7 +157,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
 
     const handleNewTransaction = useCallback(
       (tx: Transaction) => {
-        if (new BigNumber(tx.amount) > zero) {
+        if (tx.confirmed === false && new BigNumber(tx.amount) > zero) {
           handlePayment(tx);
         }
       },

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -139,7 +139,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
 
         onTransaction?.(transaction.id, receivedAmount);
 
-        if (amount && receivedAmount === new BigNumber(amount)) {
+        if (amount && receivedAmount.isEqualTo(new BigNumber(amount))) {
           setSuccess(true);
           onSuccess?.(transaction.id, receivedAmount);
         }
@@ -157,7 +157,10 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
 
     const handleNewTransaction = useCallback(
       (tx: Transaction) => {
-        if (tx.confirmed === false && new BigNumber(tx.amount) > zero) {
+        if (
+          tx.confirmed === false &&
+          zero.isLessThan(new BigNumber(tx.amount))
+        ) {
           handlePayment(tx);
         }
       },

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -28,8 +28,8 @@ export interface WidgetContainerProps
   randomSatoshis?: boolean;
   displayCurrency?: cryptoCurrency;
   hideToasts?: boolean;
-  onSuccess?: (txid: string, amount: number) => void;
-  onTransaction?: (txid: string, amount: number) => void;
+  onSuccess?: (txid: string, amount: BigNumber) => void;
+  onTransaction?: (txid: string, amount: BigNumber) => void;
   sound?: boolean;
   goalAmount?: number | string;
   disabled: boolean;
@@ -123,10 +123,10 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
     );
 
     const handlePayment = useCallback(
-      (transaction: any) => {
+      (transaction: Transaction) => {
         if (sound && !hideToasts) txSound.play().catch(() => {});
 
-        const receivedAmount = transaction.amount;
+        const receivedAmount = new BigNumber(transaction.amount);
 
         const currencyTicker = getCurrencyTypeFromAddress(to);
 
@@ -137,11 +137,11 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
             snackbarOptions,
           );
 
-        onTransaction?.(transaction, receivedAmount);
+        onTransaction?.(transaction.id, receivedAmount);
 
-        if (amount && transaction.amount === amount) {
+        if (amount && receivedAmount === new BigNumber(amount)) {
           setSuccess(true);
-          onSuccess?.(transaction, receivedAmount);
+          onSuccess?.(transaction.id, receivedAmount);
         }
       },
       [

--- a/react/src/hooks/useAddressDetails.ts
+++ b/react/src/hooks/useAddressDetails.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { AddressDetails, getAddressDetails } from '../util/api-client';
+import { Transaction, getAddressDetails } from '../util/api-client';
 import { isValidCashAddress, isValidXecAddress } from '../util/address';
 
 const POLL_DELAY = 1000;
@@ -8,8 +8,8 @@ const POLL_DELAY = 1000;
 export const useAddressDetails = (
   address: string,
   active = true,
-): AddressDetails | undefined => {
-  const [details, setDetails] = useState<AddressDetails>();
+): Transaction[] | undefined => {
+  const [details, setDetails] = useState<Transaction[]>();
 
   useEffect(() => {
     if (!address || !active) {

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -12,7 +12,7 @@ import _ from 'lodash';
 export const getAddressDetails = async (
   address: string,
   rootUrl = process.env.REACT_APP_API_URL,
-): Promise<AddressDetails> => {
+): Promise<Transaction[]> => {
   const res = await fetch(`${rootUrl}/address/transactions/${address}`);
   return res.json();
 };
@@ -144,6 +144,45 @@ export function isCrypto(
 //   legacyAddress: string;
 //   cashAddress: string;
 // }
+
+export interface Transaction {
+  id: string;
+  hash: string;
+  amount: string;
+  confirmed: boolean;
+  timestamp: number;
+  addressId: string;
+  createdAt: string;
+  updatedAt: string;
+  address: {
+    id: string;
+    address: string;
+    createdAt: string;
+    updatedAt: string;
+    networkId: number;
+    lastSynced: string;
+  };
+  prices: [
+    {
+      priceId: number;
+      transactionId: string;
+      createdAt: string;
+      updatedAt: string;
+      price: {
+        id: number;
+        value: string;
+        createdAt: string;
+        updatedAt: string;
+        timestamp: number;
+        networkId: 1;
+        quoteId: 1;
+      };
+    },
+  ];
+}
+
+// This below is old, it referred to the GRPC implementation
+/*
 export interface AddressDetails {
   confirmedTransactionsList: [ConfirmedTransaction];
   unconfirmedTransactionsList: [UnconfirmedTransaction];
@@ -230,6 +269,7 @@ export interface UnconfirmedTransaction {
   feePerKb: number;
   startingPriority: number;
 }
+*/
 
 export interface UtxoDetails {
   outputsList: [Output];


### PR DESCRIPTION
Related to #218



<!-- Non-technical, objective summary of what the PR accomplishes -->
Description
---
Fixes the toast effect.


Test plan
---
Create a button with one of your addresses and send some XEC to it to check if the effect arrives as expected
**Right now there is a problem in the prod server where the server stops registering new txs**. This won't be much testable until this is fixed.



Remarks
---
The client was still expecting the response of the `api/address/transaction/[addr]`  to be formatted as grpc. This goes on to fix the expectation to the new standardized format.
