### PR TITLE
fix: callbacks for html paybutton

### DIFF
--- a/paybutton/src/index.tsx
+++ b/paybutton/src/index.tsx
@@ -150,12 +150,12 @@ function findAndRender<T>(className: string, Component: React.ComponentType<any>
 
       if (attributes.onSuccess) {
         const geval = window.eval;
-        props.onSuccess = () => geval(attributes.onSuccess);
+        props.onSuccess = geval(attributes.onSuccess);
       }
 
       if (attributes.onTransaction) {
         const geval = window.eval;
-        props.onTransaction = () => geval(attributes.onTransaction);
+        props.onTransaction = geval(attributes.onTransaction);
       }
 
       if (attributes.theme) {


### PR DESCRIPTION
Related to #224

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fixes the problem where the `on-success` and `on-transaction` attributes of a HTML paybutton wouldn't work.



Test plan
---
Create and HTML paybutton with said attributes and check if they fire as they should. (`onSuccess` fires when the amount is equal to the expected, `onTransaction` fires regardless of the amount).

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
