### PR TITLE
feat: using config file to API urls

### DIFF
--- a/paybutton-config.json
+++ b/paybutton-config.json
@@ -1,3 +1,5 @@
 {
-  "wsBaseURL": "ws://localhost:5000"
+  "wsBaseURL": "https://sse.paybutton.org",
+  "apiBaseURL": "https://api.paybutton.org",
+  "apiPriceBaseURL": "https://api.paybutton.org"
 }

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import _ from 'lodash';
 import { Socket } from 'socket.io-client'
+import config from '../../../paybutton-config.json'
 
 // export const getAddressDetails = async (
 //   address: string,
@@ -12,7 +13,7 @@ import { Socket } from 'socket.io-client'
 // };
 export const getAddressDetails = async (
   address: string,
-  rootUrl = process.env.REACT_APP_API_URL,
+  rootUrl = config.apiBaseURL,
 ): Promise<Transaction[]> => {
   const res = await fetch(`${rootUrl}/address/transactions/${address}`);
   return res.json();
@@ -36,7 +37,7 @@ export const setListener = (socket: Socket, setNewTxs: Function): void => {
 
 export const getAddressBalance = async (
   address: string,
-  rootUrl = process.env.REACT_APP_API_URL,
+  rootUrl = config.apiBaseURL,
 ): Promise<number> => {
   const res = await axios.get(`${rootUrl}/address/balance/${address}`);
   return isNaN(res.data) ? null : res.data;
@@ -44,7 +45,7 @@ export const getAddressBalance = async (
 
 export const getUTXOs = async (
   address: string,
-  rootUrl = process.env.REACT_APP_API_URL,
+  rootUrl = config.apiBaseURL,
 ): Promise<UtxoDetails> => {
   const res = await fetch(`${rootUrl}/address/utxo/${address}`);
   return res.json();
@@ -52,7 +53,7 @@ export const getUTXOs = async (
 
 export const getBchFiatPrice = async (
   currency: currency,
-  rootUrl = process.env.REACT_APP_API_PRICING_URL,
+  rootUrl = config.apiPriceBaseURL,
 ): Promise<PriceData> => {
   const { data } = await axios.get(
     `${rootUrl}/price/bitcoincash/${_.lowerCase(currency)}`,
@@ -64,7 +65,7 @@ export const getBchFiatPrice = async (
 
 export const getXecFiatPrice = async (
   currency: currency,
-  rootUrl = process.env.REACT_APP_API_PRICING_URL,
+  rootUrl = config.apiPriceBaseURL,
 ): Promise<PriceData> => {
   const { data } = await axios.get(
     `${rootUrl}/price/ecash/${_.lowerCase(currency)}`,
@@ -77,7 +78,7 @@ export const getXecFiatPrice = async (
 export const getFiatPrice = async (
   fiat: fiatCurrency,
   crypto: cryptoCurrency,
-  rootUrl = process.env.REACT_APP_API_PRICING_URL,
+  rootUrl = config.apiPriceBaseURL,
 ): Promise<PriceData> => {
   // TODO: get rid of 'getXecFiatPrice' && 'getBchFiatPrice' and replace
   // with this function.
@@ -112,7 +113,7 @@ export const getFiatPrice = async (
 
 export const getTransactionDetails = async (
   txid: string,
-  rootUrl = process.env.REACT_APP_API_URL,
+  rootUrl = config.apiBaseURL,
 ): Promise<TransactionDetails> => {
   const res = await fetch(`${rootUrl}/transactions/details/${txid}`);
   return res.json();


### PR DESCRIPTION
Related to #223

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Makes so that the configuration of the API URL is also set on `paybutton-config.json`.


Test plan
---
Change the values set to default to e.g.:
```
{
  "wsBaseURL": "http://localhost:5000",
  "apiBaseURL": "http://localhost:3000",
  "apiPriceBaseURL": "http://localhost:3000"
}
```
...and check if the changes are now reflected into the button looking for data in the localhost server.


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
