### PR TITLE
[#229] fix: open in cashtab url

### DIFF
--- a/react/src/util/address.ts
+++ b/react/src/util/address.ts
@@ -1,5 +1,5 @@
 import * as xecaddr from 'xecaddrjs';
-import { currency } from '../util/api-client';
+import { cryptoCurrency } from '../util/api-client';
 
 export const isValidCashAddress = (address: string): boolean => {
   if (!address) return false;
@@ -23,7 +23,7 @@ export const isValidXecAddress = (address: string): boolean => {
   }
 };
 
-export const getCurrencyTypeFromAddress = (address: string): currency => {
+export const getCurrencyTypeFromAddress = (address: string): cryptoCurrency => {
   if (isValidCashAddress(address)) {
     return 'BCH';
   } else if (isValidXecAddress(address)) {

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -169,6 +169,15 @@ export function isValidCurrency(
 //   cashAddress: string;
 // }
 
+export const getCashtabProviderStatus = () => {
+  const windowAny = window as any
+  console.log(windowAny.bitcoinAbc);
+  if (window && windowAny.bitcoinAbc && windowAny.bitcoinAbc === 'cashtab') {
+    return true;
+  }
+  return false;
+};
+
 export interface Transaction {
   id: string;
   hash: string;


### PR DESCRIPTION
Related to #229 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
"Send With XEC/BCH Wallet" button now should behave as:
For ecash:
- In mobile, open the Cashtab PWA or just a cashtab.com tab in the browser, if the PWA is not installed
- In the PC, open the default app for ecash.

For bitcoincash:
- Same as before


Test plan
---
See if it works on chedieck.com/paybutton, which is currently using a `paybutton.js` built on this branch.
