### PR TITLE
fix: if no amount on button, use 0

### DIFF
--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -327,7 +327,7 @@ export const Widget: React.FC<WidgetProps> = props => {
             text: 'Cashtab',
             txInfo: {
               address: to,
-              value: thisAmount
+              value: thisAmount ?? null
             },
           },
           '*',


### PR DESCRIPTION
Related to #

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fix issue where button with no amounts would lead to opening the cashtab extension with no address.


Test plan
---
With the new paybutton.js buttons that have no amount should open the cashtab extension normally with the button address.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
