### PR TITLE
[#239] feat: URLs as parameters

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -671,9 +671,9 @@ disabled = true
 
 <!-- tabs:end -->
 
-## wsBaseURL
+## wsBaseUrl
 
-> **The ‘wsBaseURL’ parameter specifies the URL for the websocket where the information about new transactions should come.
+> **The ‘wsBaseUrl’ parameter specifies the URL for the websocket where the information about new transactions should come.
 
 ?> This parameter is optional. Default value is ‘https://socket.paybutton.org’. Possible values are any string defining an URL.
 
@@ -683,27 +683,27 @@ disabled = true
 #### ** HTML **
 
 ```html
-wsBaseURL="https://mydomain.com".
+wsBaseUrl="https://mydomain.com".
 ```
 
 #### ** JavaScript **
 
 ```javascript
-wsBaseURL: 'https://mydomain.com'
+wsBaseUrl: 'https://mydomain.com'
 ```
 
 #### ** React **
 
 ```react
-wsBaseURL = "https://mydomain.com"
+wsBaseUrl = "https://mydomain.com"
 ```
 
 <!-- tabs:end -->
 
 
-## apiBaseURL
+## apiBaseUrl
 
-> **The ‘apiBaseURL’ parameter specifies the URL for the  API where info about transactions, prices and addresses should come
+> **The ‘apiBaseUrl’ parameter specifies the URL for the  API where info about transactions, prices and addresses should come
 
 ?> This parameter is optional. Default value is ‘https://api.paybutton.org’. Possible values are any string defining an URL.
 
@@ -713,19 +713,19 @@ wsBaseURL = "https://mydomain.com"
 #### ** HTML **
 
 ```html
-apiBaseURL="https://mydomain.com".
+apiBaseUrl="https://mydomain.com".
 ```
 
 #### ** JavaScript **
 
 ```javascript
-apiBaseURL: 'https://mydomain.com'
+apiBaseUrl: 'https://mydomain.com'
 ```
 
 #### ** React **
 
 ```react
-apiBaseURL = "https://mydomain.com"
+apiBaseUrl = "https://mydomain.com"
 ```
 
 <!-- tabs:end -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -671,6 +671,66 @@ disabled = true
 
 <!-- tabs:end -->
 
+## wsBaseURL
+
+> **The ‘wsBaseURL’ parameter specifies the URL for the websocket where the information about new transactions should come.
+
+?> This parameter is optional. Default value is ‘https://socket.paybutton.org’. Possible values are any string defining an URL.
+
+**Example:**
+<!-- tabs:start -->
+
+#### ** HTML **
+
+```html
+wsBaseURL="https://mydomain.com".
+```
+
+#### ** JavaScript **
+
+```javascript
+wsBaseURL: 'https://mydomain.com'
+```
+
+#### ** React **
+
+```react
+wsBaseURL = "https://mydomain.com"
+```
+
+<!-- tabs:end -->
+
+
+## apiBaseURL
+
+> **The ‘apiBaseURL’ parameter specifies the URL for the  API where info about transactions, prices and addresses should come
+
+?> This parameter is optional. Default value is ‘https://api.paybutton.org’. Possible values are any string defining an URL.
+
+**Example:**
+<!-- tabs:start -->
+
+#### ** HTML **
+
+```html
+apiBaseURL="https://mydomain.com".
+```
+
+#### ** JavaScript **
+
+```javascript
+apiBaseURL: 'https://mydomain.com'
+```
+
+#### ** React **
+
+```react
+apiBaseURL = "https://mydomain.com"
+```
+
+<!-- tabs:end -->
+
+
 # Contribute
 
 PayButton is a community-driven open-source initiative. Contributions from the community are _crucial_ to the success of the project.

--- a/docs/README.md
+++ b/docs/README.md
@@ -683,7 +683,7 @@ disabled = true
 #### ** HTML **
 
 ```html
-wsBaseUrl="https://mydomain.com".
+ws-base-url="https://mydomain.com".
 ```
 
 #### ** JavaScript **
@@ -713,7 +713,7 @@ wsBaseUrl = "https://mydomain.com"
 #### ** HTML **
 
 ```html
-apiBaseUrl="https://mydomain.com".
+api-base-url="https://mydomain.com".
 ```
 
 #### ** JavaScript **

--- a/paybutton-config.json
+++ b/paybutton-config.json
@@ -1,4 +1,0 @@
-{
-  "wsBaseUrl": "https://socket.paybutton.org",
-  "apiBaseUrl": "https://api.paybutton.org"
-}

--- a/paybutton-config.json
+++ b/paybutton-config.json
@@ -1,4 +1,4 @@
 {
-  "wsBaseURL": "https://socket.paybutton.org",
-  "apiBaseURL": "https://api.paybutton.org"
+  "wsBaseUrl": "https://socket.paybutton.org",
+  "apiBaseUrl": "https://api.paybutton.org"
 }

--- a/paybutton-config.json
+++ b/paybutton-config.json
@@ -1,5 +1,4 @@
 {
-  "wsBaseURL": "https://sse.paybutton.org",
-  "apiBaseURL": "https://api.paybutton.org",
-  "apiPriceBaseURL": "https://api.paybutton.org"
+  "wsBaseURL": "https://socket.paybutton.org",
+  "apiBaseURL": "https://api.paybutton.org"
 }

--- a/paybutton/src/index.tsx
+++ b/paybutton/src/index.tsx
@@ -80,8 +80,8 @@ const allowedProps = [
   'disabled',
   'goalAmount',
   'editable',
-  'wsBaseURL',
-  'apiBaseURL'
+  'wsBaseUrl',
+  'apiBaseUrl'
 ];
 
 const requiredProps = [

--- a/paybutton/src/index.tsx
+++ b/paybutton/src/index.tsx
@@ -79,7 +79,9 @@ const allowedProps = [
   'to',
   'disabled',
   'goalAmount',
-  'editable'
+  'editable',
+  'wsBaseURL',
+  'apiBaseURL'
 ];
 
 const requiredProps = [

--- a/react/src/components/PayButton/PayButton.tsx
+++ b/react/src/components/PayButton/PayButton.tsx
@@ -23,8 +23,8 @@ export interface PayButtonProps extends ButtonProps {
   editable?: boolean;
   onSuccess?: (txid: string, amount: BigNumber) => void;
   onTransaction?: (txid: string, amount: BigNumber) => void;
-  wsBaseURL?: string;
-  apiBaseURL?: string;
+  wsBaseUrl?: string;
+  apiBaseUrl?: string;
 }
 
 export const PayButton = (props: PayButtonProps): React.ReactElement => {
@@ -47,8 +47,8 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
     goalAmount,
     disableEnforceFocus,
     editable,
-    wsBaseURL,
-    apiBaseURL
+    wsBaseUrl,
+    apiBaseUrl
   } = Object.assign({}, PayButton.defaultProps, props);
 
   const [hoverText, setHoverText] = useState(hoverTextDefault);
@@ -116,8 +116,8 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
         goalAmount={goalAmount}
         dialogOpen={dialogOpen}
         onClose={handleCloseDialog}
-        wsBaseURL={wsBaseURL}
-        apiBaseURL={apiBaseURL}
+        wsBaseUrl={wsBaseUrl}
+        apiBaseUrl={apiBaseUrl}
       />
       {errorMsg && (
         <p

--- a/react/src/components/PayButton/PayButton.tsx
+++ b/react/src/components/PayButton/PayButton.tsx
@@ -23,6 +23,8 @@ export interface PayButtonProps extends ButtonProps {
   editable?: boolean;
   onSuccess?: (txid: string, amount: BigNumber) => void;
   onTransaction?: (txid: string, amount: BigNumber) => void;
+  wsBaseURL?: string;
+  apiBaseURL?: string;
 }
 
 export const PayButton = (props: PayButtonProps): React.ReactElement => {
@@ -45,6 +47,8 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
     goalAmount,
     disableEnforceFocus,
     editable,
+    wsBaseURL,
+    apiBaseURL
   } = Object.assign({}, PayButton.defaultProps, props);
 
   const [hoverText, setHoverText] = useState(hoverTextDefault);
@@ -112,6 +116,8 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
         goalAmount={goalAmount}
         dialogOpen={dialogOpen}
         onClose={handleCloseDialog}
+        wsBaseURL={wsBaseURL}
+        apiBaseURL={apiBaseURL}
       />
       {errorMsg && (
         <p

--- a/react/src/components/PaymentDialog/PaymentDialog.tsx
+++ b/react/src/components/PaymentDialog/PaymentDialog.tsx
@@ -26,8 +26,8 @@ export interface PaymentDialogProps extends ButtonProps {
   onClose?: () => void;
   onSuccess?: (txid: string, amount: BigNumber) => void;
   onTransaction?: (txid: string, amount: BigNumber) => void;
-  wsBaseURL?: string;
-  apiBaseURL?: string;
+  wsBaseUrl?: string;
+  apiBaseUrl?: string;
 }
 
 export const PaymentDialog = (
@@ -52,8 +52,8 @@ export const PaymentDialog = (
     editable,
     dialogOpen,
     container,
-    wsBaseURL,
-    apiBaseURL
+    wsBaseUrl,
+    apiBaseUrl
   } = Object.assign({}, PaymentDialog.defaultProps, props);
 
   const handleWidgetClose = (): void => {
@@ -113,8 +113,8 @@ export const PaymentDialog = (
           disabled={disabled}
           editable={editable}
           goalAmount={goalAmount}
-          wsBaseURL={wsBaseURL}
-          apiBaseURL={apiBaseURL}
+          wsBaseUrl={wsBaseUrl}
+          apiBaseUrl={apiBaseUrl}
           foot={
             success && (
               <ButtonComponent

--- a/react/src/components/PaymentDialog/PaymentDialog.tsx
+++ b/react/src/components/PaymentDialog/PaymentDialog.tsx
@@ -26,6 +26,8 @@ export interface PaymentDialogProps extends ButtonProps {
   onClose?: () => void;
   onSuccess?: (txid: string, amount: BigNumber) => void;
   onTransaction?: (txid: string, amount: BigNumber) => void;
+  wsBaseURL?: string;
+  apiBaseURL?: string;
 }
 
 export const PaymentDialog = (
@@ -50,6 +52,8 @@ export const PaymentDialog = (
     editable,
     dialogOpen,
     container,
+    wsBaseURL,
+    apiBaseURL
   } = Object.assign({}, PaymentDialog.defaultProps, props);
 
   const handleWidgetClose = (): void => {
@@ -109,6 +113,8 @@ export const PaymentDialog = (
           disabled={disabled}
           editable={editable}
           goalAmount={goalAmount}
+          wsBaseURL={wsBaseURL}
+          apiBaseURL={apiBaseURL}
           foot={
             success && (
               <ButtonComponent

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -51,6 +51,8 @@ export interface WidgetProps {
   editable?: boolean;
   setNewTxs: Function; // function parent WidgetContainer passes down to be updated
   newTxs?: Transaction[]; // function parent WidgetContainer passes down to be updated
+  wsBaseURL?: string;
+  apiBaseURL?: string;
 }
 
 interface StyleProps {

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -11,7 +11,6 @@ import {
 import copy from 'copy-to-clipboard';
 import QRCode, { BaseQRCodeProps } from 'qrcode.react';
 import React, { useEffect, useMemo, useState } from 'react';
-import config from '../../../../paybutton-config.json'
 
 import { Theme, ThemeName, ThemeProvider, useTheme } from '../../themes';
 import {
@@ -24,7 +23,7 @@ import { Button, animation } from '../Button/Button';
 import BarChart from '../BarChart/BarChart';
 
 import { getCurrencyObject, currencyObject } from '../../util/satoshis';
-import { currency, getAddressBalance, getAddressDetails, isFiat, setListener, Transaction, getCashtabProviderStatus, cryptoCurrency } from '../../util/api-client';
+import { currency, getAddressBalance, getAddressDetails, isFiat, setListener, Transaction, getCashtabProviderStatus, cryptoCurrency, DEFAULT_WS_URL } from '../../util/api-client';
 import { randomizeSatoshis } from '../../util/randomizeSats';
 import PencilIcon from '../../assets/edit-pencil';
 import io from 'socket.io-client'
@@ -198,7 +197,7 @@ export const Widget: React.FC<WidgetProps> = props => {
   useEffect(() => {
     (async (): Promise<void> => {
       void await getAddressDetails(to, apiBaseUrl);
-      const socket = io(`${wsBaseUrl ?? config.wsBaseUrl}/addresses`, {
+      const socket = io(`${wsBaseUrl ?? DEFAULT_WS_URL}/addresses`, {
         query: { addresses: [to] }
       })
       setListener(socket, setNewTxs)

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -51,8 +51,8 @@ export interface WidgetProps {
   editable?: boolean;
   setNewTxs: Function; // function parent WidgetContainer passes down to be updated
   newTxs?: Transaction[]; // function parent WidgetContainer passes down to be updated
-  wsBaseURL?: string;
-  apiBaseURL?: string;
+  wsBaseUrl?: string;
+  apiBaseUrl?: string;
 }
 
 interface StyleProps {
@@ -131,8 +131,8 @@ export const Widget: React.FC<WidgetProps> = props => {
     editable,
     setNewTxs,
     newTxs,
-    apiBaseURL,
-    wsBaseURL
+    apiBaseUrl,
+    wsBaseUrl
   } = Object.assign({}, Widget.defaultProps, props);
 
   const theme = useTheme(props.theme, isValidXecAddress(to));
@@ -197,8 +197,8 @@ export const Widget: React.FC<WidgetProps> = props => {
 
   useEffect(() => {
     (async (): Promise<void> => {
-      void await getAddressDetails(to, apiBaseURL);
-      const socket = io(`${wsBaseURL ?? config.wsBaseURL}/addresses`, {
+      void await getAddressDetails(to, apiBaseUrl);
+      const socket = io(`${wsBaseUrl ?? config.wsBaseUrl}/addresses`, {
         query: { addresses: [to] }
       })
       setListener(socket, setNewTxs)
@@ -207,7 +207,7 @@ export const Widget: React.FC<WidgetProps> = props => {
 
   useEffect(() => {
     (async (): Promise<void> => {
-      const balance = await getAddressBalance(to, apiBaseURL);
+      const balance = await getAddressBalance(to, apiBaseUrl);
       setTotalReceived(balance);
     })();
   }, [newTxs]);

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -327,7 +327,7 @@ export const Widget: React.FC<WidgetProps> = props => {
             text: 'Cashtab',
             txInfo: {
               address: to,
-              value: thisAmount
+              value: thisAmount ?? null
             },
           },
           '*',

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -131,7 +131,8 @@ export const Widget: React.FC<WidgetProps> = props => {
     editable,
     setNewTxs,
     newTxs,
-    apiBaseURL
+    apiBaseURL,
+    wsBaseURL
   } = Object.assign({}, Widget.defaultProps, props);
 
   const theme = useTheme(props.theme, isValidXecAddress(to));
@@ -197,7 +198,7 @@ export const Widget: React.FC<WidgetProps> = props => {
   useEffect(() => {
     (async (): Promise<void> => {
       void await getAddressDetails(to, apiBaseURL);
-      const socket = io(`${config.wsBaseURL}/addresses`, {
+      const socket = io(`${wsBaseURL ?? config.wsBaseURL}/addresses`, {
         query: { addresses: [to] }
       })
       setListener(socket, setNewTxs)

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -131,6 +131,7 @@ export const Widget: React.FC<WidgetProps> = props => {
     editable,
     setNewTxs,
     newTxs,
+    apiBaseURL
   } = Object.assign({}, Widget.defaultProps, props);
 
   const theme = useTheme(props.theme, isValidXecAddress(to));
@@ -195,7 +196,7 @@ export const Widget: React.FC<WidgetProps> = props => {
 
   useEffect(() => {
     (async (): Promise<void> => {
-      void await getAddressDetails(to);
+      void await getAddressDetails(to, apiBaseURL);
       const socket = io(`${config.wsBaseURL}/addresses`, {
         query: { addresses: [to] }
       })
@@ -205,7 +206,7 @@ export const Widget: React.FC<WidgetProps> = props => {
 
   useEffect(() => {
     (async (): Promise<void> => {
-      const balance = await getAddressBalance(to);
+      const balance = await getAddressBalance(to, apiBaseURL);
       setTotalReceived(balance);
     })();
   }, [newTxs]);

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -35,6 +35,8 @@ export interface WidgetContainerProps
   goalAmount?: number | string;
   disabled: boolean;
   editable: boolean;
+  wsBaseURL?: string;
+  apiBaseURL?: string;
 }
 
 const snackbarOptions: OptionsObject = {
@@ -81,6 +83,8 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
       goalAmount,
       disabled,
       editable,
+      wsBaseURL,
+      apiBaseURL,
       ...widgetProps
     } = props;
 
@@ -221,6 +225,8 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
           editable={editable}
           setNewTxs={setNewTxs}
           newTxs={newTxs}
+          wsBaseURL={wsBaseURL}
+          apiBaseURL={apiBaseURL}
         />
       </React.Fragment>
     );

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -112,13 +112,13 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
     const getPrice = useCallback(async (): Promise<void> => {
       try {
         if (isFiat(currency) && isValidCashAddress(address)) {
-          const data = await getBchFiatPrice(currency);
+          const data = await getBchFiatPrice(currency, apiBaseURL);
 
           const { price } = data;
           setLoading(false);
           setPrice(price);
         } else if (isFiat(currency) && isValidXecAddress(address)) {
-          const data = await getXecFiatPrice(currency);
+          const data = await getXecFiatPrice(currency, apiBaseURL);
 
           const { price } = data;
           setLoading(false);

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -35,8 +35,8 @@ export interface WidgetContainerProps
   goalAmount?: number | string;
   disabled: boolean;
   editable: boolean;
-  wsBaseURL?: string;
-  apiBaseURL?: string;
+  wsBaseUrl?: string;
+  apiBaseUrl?: string;
 }
 
 const snackbarOptions: OptionsObject = {
@@ -83,8 +83,8 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
       goalAmount,
       disabled,
       editable,
-      wsBaseURL,
-      apiBaseURL,
+      wsBaseUrl,
+      apiBaseUrl,
       ...widgetProps
     } = props;
 
@@ -112,13 +112,13 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
     const getPrice = useCallback(async (): Promise<void> => {
       try {
         if (isFiat(currency) && isValidCashAddress(address)) {
-          const data = await getBchFiatPrice(currency, apiBaseURL);
+          const data = await getBchFiatPrice(currency, apiBaseUrl);
 
           const { price } = data;
           setLoading(false);
           setPrice(price);
         } else if (isFiat(currency) && isValidXecAddress(address)) {
-          const data = await getXecFiatPrice(currency, apiBaseURL);
+          const data = await getXecFiatPrice(currency, apiBaseUrl);
 
           const { price } = data;
           setLoading(false);
@@ -225,8 +225,8 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
           editable={editable}
           setNewTxs={setNewTxs}
           newTxs={newTxs}
-          wsBaseURL={wsBaseURL}
-          apiBaseURL={apiBaseURL}
+          wsBaseUrl={wsBaseUrl}
+          apiBaseUrl={apiBaseUrl}
         />
       </React.Fragment>
     );

--- a/react/src/hooks/useAddressDetails.ts
+++ b/react/src/hooks/useAddressDetails.ts
@@ -5,6 +5,7 @@ import { isValidCashAddress, isValidXecAddress } from '../util/address';
 
 const POLL_DELAY = 1000;
 
+// DEPRECATED this was used before websockets
 export const useAddressDetails = (
   address: string,
   active = true,

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -13,7 +13,7 @@ import config from '../../../paybutton-config.json'
 // };
 export const getAddressDetails = async (
   address: string,
-  rootUrl = config.apiBaseURL,
+  rootUrl = config.apiBaseUrl,
 ): Promise<Transaction[]> => {
   const res = await fetch(`${rootUrl}/address/transactions/${address}`);
   return res.json();
@@ -37,7 +37,7 @@ export const setListener = (socket: Socket, setNewTxs: Function): void => {
 
 export const getAddressBalance = async (
   address: string,
-  rootUrl = config.apiBaseURL,
+  rootUrl = config.apiBaseUrl,
 ): Promise<number> => {
   const res = await axios.get(`${rootUrl}/address/balance/${address}`);
   return isNaN(res.data) ? null : res.data;
@@ -45,7 +45,7 @@ export const getAddressBalance = async (
 
 export const getUTXOs = async (
   address: string,
-  rootUrl = config.apiBaseURL,
+  rootUrl = config.apiBaseUrl,
 ): Promise<UtxoDetails> => {
   const res = await fetch(`${rootUrl}/address/utxo/${address}`);
   return res.json();
@@ -53,7 +53,7 @@ export const getUTXOs = async (
 
 export const getBchFiatPrice = async (
   currency: currency,
-  rootUrl = config.apiBaseURL,
+  rootUrl = config.apiBaseUrl,
 ): Promise<PriceData> => {
   const { data } = await axios.get(
     `${rootUrl}/price/bitcoincash/${_.lowerCase(currency)}`,
@@ -65,7 +65,7 @@ export const getBchFiatPrice = async (
 
 export const getXecFiatPrice = async (
   currency: currency,
-  rootUrl = config.apiBaseURL,
+  rootUrl = config.apiBaseUrl,
 ): Promise<PriceData> => {
   const { data } = await axios.get(
     `${rootUrl}/price/ecash/${_.lowerCase(currency)}`,
@@ -78,7 +78,7 @@ export const getXecFiatPrice = async (
 export const getFiatPrice = async (
   fiat: fiatCurrency,
   crypto: cryptoCurrency,
-  rootUrl = config.apiBaseURL,
+  rootUrl = config.apiBaseUrl,
 ): Promise<PriceData> => {
   // TODO: get rid of 'getXecFiatPrice' && 'getBchFiatPrice' and replace
   // with this function.
@@ -113,7 +113,7 @@ export const getFiatPrice = async (
 
 export const getTransactionDetails = async (
   txid: string,
-  rootUrl = config.apiBaseURL,
+  rootUrl = config.apiBaseUrl,
 ): Promise<TransactionDetails> => {
   const res = await fetch(`${rootUrl}/transactions/details/${txid}`);
   return res.json();

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -53,7 +53,7 @@ export const getUTXOs = async (
 
 export const getBchFiatPrice = async (
   currency: currency,
-  rootUrl = config.apiPriceBaseURL,
+  rootUrl = config.apiBaseURL,
 ): Promise<PriceData> => {
   const { data } = await axios.get(
     `${rootUrl}/price/bitcoincash/${_.lowerCase(currency)}`,
@@ -65,7 +65,7 @@ export const getBchFiatPrice = async (
 
 export const getXecFiatPrice = async (
   currency: currency,
-  rootUrl = config.apiPriceBaseURL,
+  rootUrl = config.apiBaseURL,
 ): Promise<PriceData> => {
   const { data } = await axios.get(
     `${rootUrl}/price/ecash/${_.lowerCase(currency)}`,
@@ -78,7 +78,7 @@ export const getXecFiatPrice = async (
 export const getFiatPrice = async (
   fiat: fiatCurrency,
   crypto: cryptoCurrency,
-  rootUrl = config.apiPriceBaseURL,
+  rootUrl = config.apiBaseURL,
 ): Promise<PriceData> => {
   // TODO: get rid of 'getXecFiatPrice' && 'getBchFiatPrice' and replace
   // with this function.

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -1,19 +1,13 @@
 import axios from 'axios';
 import _ from 'lodash';
 import { Socket } from 'socket.io-client'
-import config from '../../../paybutton-config.json'
 
-// export const getAddressDetails = async (
-//   address: string,
-// ): Promise<AddressDetails> => {
-//   const res = await fetch(
-//     `https://rest.bitcoin.com/v2/address/details/${address}`,
-//   );
-//   return res.json();
-// };
+export const DEFAULT_WS_URL = "https://socket.paybutton.org"
+export const DEFAULT_API_URL = "https://api.paybutton.org"
+
 export const getAddressDetails = async (
   address: string,
-  rootUrl = config.apiBaseUrl,
+  rootUrl = DEFAULT_API_URL,
 ): Promise<Transaction[]> => {
   const res = await fetch(`${rootUrl}/address/transactions/${address}`);
   return res.json();
@@ -37,7 +31,7 @@ export const setListener = (socket: Socket, setNewTxs: Function): void => {
 
 export const getAddressBalance = async (
   address: string,
-  rootUrl = config.apiBaseUrl,
+  rootUrl = DEFAULT_API_URL,
 ): Promise<number> => {
   const res = await axios.get(`${rootUrl}/address/balance/${address}`);
   return isNaN(res.data) ? null : res.data;
@@ -45,7 +39,7 @@ export const getAddressBalance = async (
 
 export const getUTXOs = async (
   address: string,
-  rootUrl = config.apiBaseUrl,
+  rootUrl = DEFAULT_API_URL,
 ): Promise<UtxoDetails> => {
   const res = await fetch(`${rootUrl}/address/utxo/${address}`);
   return res.json();
@@ -53,7 +47,7 @@ export const getUTXOs = async (
 
 export const getBchFiatPrice = async (
   currency: currency,
-  rootUrl = config.apiBaseUrl,
+  rootUrl = DEFAULT_API_URL,
 ): Promise<PriceData> => {
   const { data } = await axios.get(
     `${rootUrl}/price/bitcoincash/${_.lowerCase(currency)}`,
@@ -65,7 +59,7 @@ export const getBchFiatPrice = async (
 
 export const getXecFiatPrice = async (
   currency: currency,
-  rootUrl = config.apiBaseUrl,
+  rootUrl = DEFAULT_API_URL,
 ): Promise<PriceData> => {
   const { data } = await axios.get(
     `${rootUrl}/price/ecash/${_.lowerCase(currency)}`,
@@ -78,7 +72,7 @@ export const getXecFiatPrice = async (
 export const getFiatPrice = async (
   fiat: fiatCurrency,
   crypto: cryptoCurrency,
-  rootUrl = config.apiBaseUrl,
+  rootUrl = DEFAULT_API_URL,
 ): Promise<PriceData> => {
   // TODO: get rid of 'getXecFiatPrice' && 'getBchFiatPrice' and replace
   // with this function.
@@ -113,7 +107,7 @@ export const getFiatPrice = async (
 
 export const getTransactionDetails = async (
   txid: string,
-  rootUrl = config.apiBaseUrl,
+  rootUrl = DEFAULT_API_URL,
 ): Promise<TransactionDetails> => {
   const res = await fetch(`${rootUrl}/transactions/details/${txid}`);
   return res.json();


### PR DESCRIPTION
Related to #239


Depends on
---
- [ ] #241



<!-- Non-technical -->
Description
---
- Adds option of adding the `ws-base-url` and `api-base-url` parameters to a paybutton (JS would be `wsBaseUrl` and `apiBaseUrl`) to override the defaults.


Test plan
---
With the JS compiled from this branch, create a HTML & JS paybutton overriding this URLs (see the modified docs for more info), it should override as expected.
 
Remarks
---

- Removes the `paybutton-config.json`, uses simple constants in the code to define the default values
- Simplify the existance of `apiBaseURL` and `apiPriceBaseURL` to just `apiBaseUrl`. This `apiBaseUrl` is already used to fetch a lot of different info, all from the same place (our server), so it made no sense to distinguish the price like this.

