### PR TITLE
[#247] fix: random satoshis for both currencies

### DIFF
--- a/paybutton/src/index.tsx
+++ b/paybutton/src/index.tsx
@@ -146,7 +146,7 @@ function findAndRender<T>(className: string, Component: React.ComponentType<any>
       }
 
       props.hideToasts = attributes.hideToasts === 'true';
-      props.randomSatoshis = attributes.randomSatoshis === 'true';
+      props.randomSatoshis = attributes.randomSatoshis === 'false' ? false : true;
 
       if (attributes.onSuccess) {
         const geval = window.eval;

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -154,7 +154,7 @@ export const Widget: React.FC<WidgetProps> = props => {
   const [text, setText] = useState('Send any amount of BCH');
   const [widgetButtonText, setWidgetButtonText] = useState('Send Payment');
   const transformAmount = useMemo(
-    () => (randomSatoshis ? randomizeSatoshis : (x: number): number => x),
+    () => (randomSatoshis ? randomizeSatoshis : (x: number, _: string): number => x),
     [randomSatoshis],
   );
 
@@ -243,17 +243,17 @@ export const Widget: React.FC<WidgetProps> = props => {
       }
     }
 
-    if (userEditedAmount !== undefined && amount) {
-      const obj = getCurrencyObject(transformAmount(+amount), currency);
+    if (userEditedAmount !== undefined && amount && addressType) {
+      const obj = getCurrencyObject(transformAmount(+amount, addressType), currency);
       setCurrencyObj(obj);
-    } else if (amount) {
+    } else if (amount && addressType) {
       cleanAmount = +amount;
       if (currencyObj === undefined) {
-        const obj = getCurrencyObject(transformAmount(cleanAmount), currency);
+        const obj = getCurrencyObject(transformAmount(cleanAmount, addressType), currency);
         setCurrencyObj(obj);
       }
     }
-  }, [amount, currency, userEditedAmount]);
+  }, [amount, currency, userEditedAmount, addressType]);
 
   useEffect(() => {
     if (to === undefined) {

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -25,7 +25,6 @@ import BarChart from '../BarChart/BarChart';
 
 import { getCurrencyObject, currencyObject } from '../../util/satoshis';
 import { currency, getAddressBalance, getAddressDetails, isFiat, setListener, Transaction, getCashtabProviderStatus, cryptoCurrency } from '../../util/api-client';
-import { randomizeSatoshis } from '../../util/randomizeSats';
 import PencilIcon from '../../assets/edit-pencil';
 import io from 'socket.io-client'
 
@@ -153,10 +152,6 @@ export const Widget: React.FC<WidgetProps> = props => {
   const [userEditedAmount, setUserEditedAmount] = useState<currencyObject>();
   const [text, setText] = useState('Send any amount of BCH');
   const [widgetButtonText, setWidgetButtonText] = useState('Send Payment');
-  const transformAmount = useMemo(
-    () => (randomSatoshis ? randomizeSatoshis : (x: number, _: string): number => x),
-    [randomSatoshis],
-  );
 
   const blurCSS = disabled ? { filter: 'blur(5px)' } : {};
 
@@ -244,12 +239,12 @@ export const Widget: React.FC<WidgetProps> = props => {
     }
 
     if (userEditedAmount !== undefined && amount && addressType) {
-      const obj = getCurrencyObject(transformAmount(+amount, addressType), currency);
+      const obj = getCurrencyObject(+amount, currency, randomSatoshis);
       setCurrencyObj(obj);
     } else if (amount && addressType) {
       cleanAmount = +amount;
       if (currencyObj === undefined) {
-        const obj = getCurrencyObject(transformAmount(cleanAmount, addressType), currency);
+        const obj = getCurrencyObject(cleanAmount, currency, randomSatoshis);
         setCurrencyObj(obj);
       }
     }
@@ -278,7 +273,7 @@ export const Widget: React.FC<WidgetProps> = props => {
 
     if (currencyObj && hasPrice) {
       const convertedObj = price
-        ? getCurrencyObject(currencyObj.float / price, addressType)
+        ? getCurrencyObject(currencyObj.float / price, addressType, randomSatoshis)
         : null;
 
       if (convertedObj) {
@@ -384,7 +379,7 @@ export const Widget: React.FC<WidgetProps> = props => {
       amount = '0';
     }
 
-    const userEdited = getCurrencyObject(+amount, currency);
+    const userEdited = getCurrencyObject(+amount, currency, randomSatoshis);
 
     setUserEditedAmount(userEdited);
     setAmount(amount);
@@ -392,9 +387,9 @@ export const Widget: React.FC<WidgetProps> = props => {
 
   useEffect(() => {
     if (totalReceived !== undefined) {
-      const progress = getCurrencyObject(totalReceived, currency);
+      const progress = getCurrencyObject(totalReceived, currency, false);
 
-      const goal = getCurrencyObject(cleanGoalAmount, currency);
+      const goal = getCurrencyObject(cleanGoalAmount, currency, false);
       if (!isFiat(currency)) {
         if (goal !== undefined) {
           setGoalPercent((100 * progress.float) / goal.float);

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -179,7 +179,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
 
     useEffect(() => {
       if (props.amount && currency) {
-        const obj = getCurrencyObject(props.amount, currency);
+        const obj = getCurrencyObject(props.amount, currency, randomSatoshis);
         setAmount(obj.float);
         setCurrencyObj(obj);
       }

--- a/react/src/util/randomizeSats.ts
+++ b/react/src/util/randomizeSats.ts
@@ -6,7 +6,7 @@ export const randomizeSatoshis = (amount: number): number => {
 
   // 0-99: 10 second window, resets every 16.5 minutes
   const window =
-    Math.floor((date.getUTCMinutes() * 60 + date.getUTCSeconds()) / 10) % 90;
+    Math.floor((date.getUTCMinutes() * 60 + date.getUTCSeconds()) / 10) % 100;
   // 0-99: random
   const random = Math.floor(Math.random() * 100);
 

--- a/react/src/util/randomizeSats.ts
+++ b/react/src/util/randomizeSats.ts
@@ -1,4 +1,5 @@
-export const randomizeSatoshis = (amount: number): number => {
+import { cryptoCurrency } from './api-client';
+export const randomizeSatoshis = (amount: number, addressType: cryptoCurrency): number => {
   if (amount === 0) {
     return 0;
   }
@@ -9,12 +10,30 @@ export const randomizeSatoshis = (amount: number): number => {
     Math.floor((date.getUTCMinutes() * 60 + date.getUTCSeconds()) / 10) % 100;
   // 0-99: random
   const random = Math.floor(Math.random() * 100);
-
-  const randomizedAmount =
-    Math.max(0, +amount.toFixed(4)) + // zero out the 4 least-significant digits
-    random * 1e-6 + // Two random digits
-    window * 1e-8; // Two digits for the time window
-  return +randomizedAmount.toFixed(8);
+  let randomToAdd: number
+  let randomizedAmount: number
+  let ret: number
+  switch (addressType) {
+    case 'BCH':
+      randomToAdd = random * 1e-6 + // Two random digits
+        window * 1e-8; // Two digits for the time window
+      randomizedAmount =
+        Math.max(0, +amount.toFixed(4)) + // zero out the 4 least-significant digits
+        randomToAdd
+      ret = +randomizedAmount.toFixed(8);
+      break
+    case 'XEC':
+      randomToAdd = random * 1 + // Two random digits
+        window * 1e-2; // Two digits for the time window
+      randomizedAmount =
+        Math.max(0, +(amount/100).toFixed(0)) + // zero out the 4 least-significant digits
+        randomToAdd
+      ret = +randomizedAmount.toFixed(2);
+      break
+    default:
+      throw new Error(`Invalid currency: ${addressType}`)
+  }
+  return ret
 };
 
 export default randomizeSatoshis;

--- a/react/src/util/randomizeSats.ts
+++ b/react/src/util/randomizeSats.ts
@@ -26,7 +26,7 @@ export const randomizeSatoshis = (amount: number, addressType: cryptoCurrency): 
       randomToAdd = random * 1 + // Two random digits
         window * 1e-2; // Two digits for the time window
       randomizedAmount =
-        Math.max(0, +(amount/100).toFixed(0)) + // zero out the 4 least-significant digits
+        Math.max(0, +(Math.floor(amount/100) * 100)) + // zero out the 4 least-significant digits
         randomToAdd
       ret = +randomizedAmount.toFixed(2);
       break

--- a/react/src/util/satoshis.ts
+++ b/react/src/util/satoshis.ts
@@ -1,6 +1,7 @@
 import BigNumber from 'bignumber.js';
 import { formatPrice, formatBCH, formatXEC, DECIMALS } from './format';
 import { currency } from './api-client';
+import { randomizeSatoshis } from './randomizeSats';
 
 export type currencyObject = {
   float: number;
@@ -11,25 +12,25 @@ export type currencyObject = {
 export const getCurrencyObject = (
   amount: number,
   currencyType: currency,
+  randomSatoshis: boolean
 ): currencyObject => {
   let string = '';
   let float = 0;
 
-  if (currencyType === 'BCH') {
-    const primaryUnit = new BigNumber(`${amount}`);
-
-    if (primaryUnit !== null && primaryUnit.c !== null) {
-      float = parseFloat(new BigNumber(primaryUnit).toFixed(DECIMALS.BCH));
-      string = new BigNumber(`${primaryUnit}`).toFixed(DECIMALS.BCH);
-      string = formatBCH(string);
+  if (currencyType === 'BCH' || currencyType === 'XEC') {
+    let newAmount = amount
+    if (randomSatoshis) {
+      newAmount = randomizeSatoshis(amount, currencyType)
     }
-  } else if (currencyType === 'XEC') {
-    const primaryUnit = new BigNumber(`${amount}`);
-
+    let primaryUnit = new BigNumber(`${newAmount}`);
     if (primaryUnit !== null && primaryUnit.c !== null) {
-      float = parseFloat(new BigNumber(primaryUnit).toFixed(DECIMALS.XEC));
-      string = new BigNumber(`${primaryUnit}`).toFixed(DECIMALS.XEC);
-      string = formatXEC(string);
+      float = parseFloat(new BigNumber(primaryUnit).toFixed(DECIMALS[currencyType]));
+      string = new BigNumber(`${primaryUnit}`).toFixed(DECIMALS[currencyType]);
+      if (currencyType === 'BCH') {
+        string = formatBCH(string);
+      } else if (currencyType === 'XEC') {
+        string = formatXEC(string);
+      }
     }
   } else {
     float = amount;


### PR DESCRIPTION
Related to #247

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Makes so that the `random-satoshis` option works well for both XEC and BCH, also makes `true` the default for it.


Test plan
---
1. Unless `random-satoshis="false"` is explicitly set, should be true.
2. For BCH and XEC, the last 4 digits should be ignored and randomized. This means the end should vary from `0.00000000` to `0.00009999` with BCH and from `0.00` to `99.99` on XEC.


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
