### PR TITLE
[S#669] fix: remove redundant breaking hovertext default setting

### DIFF
--- a/react/src/components/PayButton/PayButton.tsx
+++ b/react/src/components/PayButton/PayButton.tsx
@@ -37,7 +37,7 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
     amount,
     currency,
     text,
-    hoverText: hoverTextDefault,
+    hoverText,
     successText,
     animation,
     randomSatoshis,
@@ -50,8 +50,6 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
     wsBaseUrl,
     apiBaseUrl
   } = Object.assign({}, PayButton.defaultProps, props);
-
-  const [hoverText, setHoverText] = useState(hoverTextDefault);
 
   const handleButtonClick = (): void => setDialogOpen(true);
   const handleCloseDialog = (): void => setDialogOpen(false);
@@ -73,14 +71,12 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
 
   useEffect(() => {
     if (!to) {
-      setHoverText(hoverTextDefault);
       setErrorMsg('Enter an address');
     } else if (isValidCashAddress(to)) {
       setErrorMsg('');
     } else if (isValidXecAddress(to)) {
       setErrorMsg('');
     } else {
-      setHoverText(hoverTextDefault);
       setErrorMsg('Invalid Recipient');
     }
   }, [to]);


### PR DESCRIPTION
Related to https://github.com/PayButton/paybutton-server/issues/669

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fixes the issue where changing the `hoverText` input field on the button generator wouldn't reflect on the button Preview.


Test plan
---
Since this was breaking the server generator, testing is a bit clumsy:
- Build the react module with `cd react && npm run build`
- On the **server** directory, go to `paybutton-server/node_modules/@paybutton/react`, delete everything, and then paste the content of this repo's `react/` folder. Something like `cp paybutton/react/* paybutton-server/node_modules/@paybutton/react/`
- Go to the localhost and try the button generator. The issue should be gone.

PS: The default text `Send Payment` should work normally. It is set on the `Button` component and it was being redundantly wrongly set on the `PayButton` component.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
