### PR TITLE
[#262] fix: no comma in amount & randomized amount in cashtab

### DIFF
--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -296,7 +296,7 @@ export const Widget: React.FC<WidgetProps> = props => {
       if (!isFiat(currency) && currencyObj && notZeroValue) {
         const bchType: string = currencyObj.currency;
         setText(`Send ${currencyObj.string} ${bchType}`);
-        query.push(`amount=${currencyObj.string}`);
+        query.push(`amount=${currencyObj.float}`);
         url = prefixedAddress + (query.length ? `?${query.join('&')}` : '');
         setUrl(url);
       } else {

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -310,7 +310,7 @@ export const Widget: React.FC<WidgetProps> = props => {
   const handleButtonClick = () => {
     if (addressType === 'XEC'){
       const hasExtension = getCashtabProviderStatus()
-      const thisAmount = convertedCurrencyObj ? convertedCurrencyObj.float : amount
+      const thisAmount = (convertedCurrencyObj ? convertedCurrencyObj.float : currencyObj.float)
       if (!hasExtension) {
         window.location.href = url;
         const isMobile = window.matchMedia("(pointer:coarse)").matches;

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -310,7 +310,12 @@ export const Widget: React.FC<WidgetProps> = props => {
   const handleButtonClick = () => {
     if (addressType === 'XEC'){
       const hasExtension = getCashtabProviderStatus()
-      const thisAmount = (convertedCurrencyObj ? convertedCurrencyObj.float : currencyObj.float)
+      let thisAmount: number | undefined
+      if (convertedCurrencyObj) {
+        thisAmount = convertedCurrencyObj.float
+      } else {
+        thisAmount = (currencyObj ? currencyObj.float : undefined)
+      }
       if (!hasExtension) {
         window.location.href = url;
         const isMobile = window.matchMedia("(pointer:coarse)").matches;


### PR DESCRIPTION
Related to #262

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fixes #262 and also fixes the second problem where the amount after opening cashtab would not be randomized.


Test plan
---
With this `paybutton.js`, opening the cashtab app after clicking "Send with XEC wallet" should have the correct amount set.
Also a button with no amount set should continue to open cashtab with nothing in the amount filled.
<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
