### PR TITLE
[S#675] fix: only care about incoming unconfirmed txs

### DIFF
--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -20,8 +20,9 @@ export interface BroadcastTxData {
 
 export const setListener = (socket: Socket, setNewTxs: Function): void => {
   socket.on('incoming-txs', (broadcastedTxData: BroadcastTxData) => {
-    if (broadcastedTxData.messageType === 'NewTx') {
-      setNewTxs(broadcastedTxData.txs)
+    const unconfirmedTxs = broadcastedTxData.txs.filter(tx => tx.confirmed === false)
+    if (broadcastedTxData.messageType === 'NewTx' && unconfirmedTxs.length !== 0) {
+      setNewTxs(unconfirmedTxs)
     }
   })
 }


### PR DESCRIPTION
Related to https://github.com/PayButton/paybutton-server/issues/675

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Makes so that we only care about new unconfirmed txs.
Since right now the client is not broadcasting incoming confirmed txs, this would be innocuous.  https://github.com/PayButton/paybutton-server/pull/676 will make so that confirmed txs are broadcasted (in order to update the txs for users seeing the button detail view in the server), so this should be released before https://github.com/PayButton/paybutton-server/pull/676 is live. 


Test plan
---
Should work just as before.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
