### PR TITLE
feat: onSuccess and onTransaction do not fire both

### DIFF
--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -313,7 +313,7 @@ export const Widget: React.FC<WidgetProps> = props => {
       if (convertedCurrencyObj) {
         thisAmount = convertedCurrencyObj.float
       } else {
-        thisAmount = (currencyObj ? currencyObj.float : undefined)
+        thisAmount = (currencyObject ? currencyObject.float : undefined)
       }
       if (!hasExtension) {
         window.location.href = url;

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -45,6 +45,7 @@ export interface WidgetProps {
   currency?: currency;
   animation?: animation;
   currencyObject?: currencyObject | undefined;
+  setCurrencyObject: Function;
   randomSatoshis?: boolean;
   price?: number;
   editable?: boolean;
@@ -127,6 +128,7 @@ export const Widget: React.FC<WidgetProps> = props => {
     animation,
     randomSatoshis = true,
     currencyObject,
+    setCurrencyObject,
     editable,
     setNewTxs,
     newTxs,
@@ -146,9 +148,6 @@ export const Widget: React.FC<WidgetProps> = props => {
   const [goalText, setGoalText] = useState('');
   const [goalPercent, setGoalPercent] = useState(0);
   const [addressType, setAddressType] = useState<cryptoCurrency>();
-  const [currencyObj, setCurrencyObj] = useState<currencyObject>(
-    currencyObject!,
-  );
   const [convertedCurrencyObj, setConvertedCurrencyObj] = useState<currencyObject|null>();
   const price = props.price;
   const [amount, setAmount] = useState(props.amount);
@@ -244,12 +243,12 @@ export const Widget: React.FC<WidgetProps> = props => {
 
     if (userEditedAmount !== undefined && amount && addressType) {
       const obj = getCurrencyObject(+amount, currency, randomSatoshis);
-      setCurrencyObj(obj);
+      setCurrencyObject(obj);
     } else if (amount && addressType) {
       cleanAmount = +amount;
-      if (currencyObj === undefined) {
+      if (currencyObject === undefined) {
         const obj = getCurrencyObject(cleanAmount, currency, randomSatoshis);
-        setCurrencyObj(obj);
+        setCurrencyObject(obj);
       }
     }
   }, [amount, currency, userEditedAmount, addressType]);
@@ -275,15 +274,15 @@ export const Widget: React.FC<WidgetProps> = props => {
     }
     url = prefixedAddress + (query.length ? `?${query.join('&')}` : '');
 
-    if (currencyObj && hasPrice) {
+    if (currencyObject && hasPrice) {
       const convertedObj = price
-        ? getCurrencyObject(currencyObj.float / price, addressType, randomSatoshis)
+        ? getCurrencyObject(currencyObject.float / price, addressType, randomSatoshis)
         : null;
 
       if (convertedObj) {
         setConvertedCurrencyObj(convertedObj)
         setText(
-          `Send ${currencyObj.string} ${currencyObj.currency} = ${convertedObj.string} ${addressType}`,
+          `Send ${currencyObject.string} ${currencyObject.currency} = ${convertedObj.string} ${addressType}`,
         );
         query.push(`amount=${convertedObj.float}`);
       }
@@ -292,11 +291,11 @@ export const Widget: React.FC<WidgetProps> = props => {
       setUrl(url);
     } else {
       const notZeroValue: boolean =
-        currencyObj?.float !== undefined && currencyObj.float > 0;
-      if (!isFiat(currency) && currencyObj && notZeroValue) {
-        const bchType: string = currencyObj.currency;
-        setText(`Send ${currencyObj.string} ${bchType}`);
-        query.push(`amount=${currencyObj.string}`);
+        currencyObject?.float !== undefined && currencyObject.float > 0;
+      if (!isFiat(currency) && currencyObject && notZeroValue) {
+        const bchType: string = currencyObject.currency;
+        setText(`Send ${currencyObject.string} ${bchType}`);
+        query.push(`amount=${currencyObject.string}`);
         url = prefixedAddress + (query.length ? `?${query.join('&')}` : '');
         setUrl(url);
       } else {
@@ -305,7 +304,7 @@ export const Widget: React.FC<WidgetProps> = props => {
         setUrl(url);
       }
     }
-  }, [currencyObj, price, amount]);
+  }, [currencyObject, price, amount]);
 
   const handleButtonClick = () => {
     if (addressType === 'XEC'){

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -219,6 +219,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
           currency={currency}
           animation={animation}
           currencyObject={currencyObj}
+          setCurrencyObject={setCurrencyObj}
           loading={loading}
           randomSatoshis={randomSatoshis}
           price={price}

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -151,11 +151,11 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
             snackbarOptions,
           );
 
-        onTransaction?.(transaction.id, receivedAmount);
-
         if (amount && receivedAmount.isEqualTo(new BigNumber(amount))) {
           setSuccess(true);
           onSuccess?.(transaction.id, receivedAmount);
+        } else {
+          onTransaction?.(transaction.id, receivedAmount);
         }
         setNewTxs([])
       },


### PR DESCRIPTION

Depends on
---
- [ ] #268


<!-- Non-technical -->
Description
---
Changes so that the behavior of the `onSuccess` and `onTransaction` functions is:
`onSuccess`: fires if the incoming transaction amount is the same of the button. If no amount is set, never fires.
onTransaction: fires in all other cases

Test plan
---
Check that the behavior described above is correct for buttons with or without amount.


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
