### PR TITLE
[#281] feat: buffed random satoshis

### DIFF
--- a/paybutton/src/index.tsx
+++ b/paybutton/src/index.tsx
@@ -164,8 +164,8 @@ function findAndRender<T>(className: string, Component: React.ComponentType<any>
           break
         default:
           props.randomSatoshis = +attributes.randomSatoshis
-          if (isNaN(props.randomSatoshis) || props.randomSatoshis > 8) {
-            console.error('randomSatoshis must be true, false, or a number smaller or equal than 8.')
+          if (isNaN(props.randomSatoshis)) {
+            console.error('randomSatoshis must be true, false, or a number.')
           }
       }
 

--- a/paybutton/src/index.tsx
+++ b/paybutton/src/index.tsx
@@ -153,6 +153,21 @@ function findAndRender<T>(className: string, Component: React.ComponentType<any>
 
       props.hideToasts = attributes.hideToasts === 'true';
       props.randomSatoshis = attributes.randomSatoshis === 'false' ? false : true;
+      switch (attributes.randomSatoshis) {
+        case '':
+        case undefined:
+        case 'true':
+          props.randomSatoshis = true
+          break
+        case 'false':
+          props.randomSatoshis = false
+          break
+        default:
+          props.randomSatoshis = +attributes.randomSatoshis
+          if (isNaN(props.randomSatoshis) || props.randomSatoshis > 8) {
+            console.error('randomSatoshis must be true, false, or a number smaller or equal than 8.')
+          }
+      }
 
       if (attributes.onSuccess) {
         const geval = window.eval;

--- a/react/src/components/PayButton/PayButton.tsx
+++ b/react/src/components/PayButton/PayButton.tsx
@@ -15,7 +15,7 @@ export interface PayButtonProps extends ButtonProps {
   text?: string;
   hoverText?: string;
   successText?: string;
-  randomSatoshis?: boolean;
+  randomSatoshis?: boolean | number;
   hideToasts?: boolean;
   disabled?: boolean;
   goalAmount?: number | string;

--- a/react/src/components/PaymentDialog/PaymentDialog.tsx
+++ b/react/src/components/PaymentDialog/PaymentDialog.tsx
@@ -14,7 +14,7 @@ export interface PaymentDialogProps extends ButtonProps {
   currency?: currency;
   theme?: ThemeName | Theme;
   successText?: string;
-  randomSatoshis?: boolean;
+  randomSatoshis?: boolean | number;
   hideToasts?: boolean;
   goalAmount?: number | string;
   disableEnforceFocus?: boolean;

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -47,7 +47,7 @@ export interface WidgetProps {
   animation?: animation;
   currencyObject?: currencyObject | undefined;
   setCurrencyObject: Function;
-  randomSatoshis?: boolean;
+  randomSatoshis?: boolean | number;
   price?: number;
   editable?: boolean;
   setNewTxs: Function; // function parent WidgetContainer passes down to be updated

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -26,7 +26,7 @@ export interface WidgetContainerProps
   active?: boolean;
   amount?: number;
   currency?: currency;
-  randomSatoshis?: boolean;
+  randomSatoshis?: boolean | number;
   displayCurrency?: cryptoCurrency;
   hideToasts?: boolean;
   onSuccess?: (txid: string, amount: BigNumber) => void;

--- a/react/src/util/randomizeSats.ts
+++ b/react/src/util/randomizeSats.ts
@@ -4,8 +4,8 @@ const DEFAULT = 3
 const MAX = 4
 
 
-export const getNSatoshis = (amount: number, randomSatoshis: boolean | number): number => {
-  const amountDigits = amount.toString().replace('.', '').length;
+export const getNSatoshis = (amount: number, randomSatoshis: boolean | number, satsPrecision: number): number => {
+  const amountDigits = amount.toFixed(satsPrecision).toString().replace('.', '').length;
   if (randomSatoshis === true) {
     return Math.min(DEFAULT, amountDigits)
   } else if (randomSatoshis === false) {
@@ -21,25 +21,27 @@ export const randomizeSatoshis = (amount: number, addressType: cryptoCurrency, r
   if (amount === 0) {
     return 0;
   }
-  const nSatoshis = getNSatoshis(amount, randomSatoshis)
-
-  const random = Math.floor(Math.random() * 10 ** nSatoshis);
-  let randomToAdd: number
+  let nSatoshis: number
+  let random: number
   let randomizedAmount: number
   let ret: number
   switch (addressType) {
     case 'BCH':
-      randomToAdd = random * 1e-8
+      nSatoshis = getNSatoshis(amount, randomSatoshis, 8)
+      random = Math.floor(Math.random() * 10 ** nSatoshis) * 1e-8
+
       randomizedAmount =
         Math.max(0, +amount.toFixed(nSatoshis)) + // zero out the least-significant digits
-        randomToAdd
+        random
       ret = +randomizedAmount.toFixed(8);
       break
     case 'XEC':
-      randomToAdd = random * 1e-2;
+      nSatoshis = getNSatoshis(amount, randomSatoshis, 2)
+      random = Math.floor(Math.random() * 10 ** nSatoshis) * 1e-2
+
         const multiplier = 10 ** (nSatoshis - 2)
         randomizedAmount = Math.max(0, +(Math.floor(amount / multiplier) * multiplier)) + // zero out the least-significant digits
-        randomToAdd
+        random
       ret = +randomizedAmount.toFixed(2);
       break
     default:

--- a/react/src/util/randomizeSats.ts
+++ b/react/src/util/randomizeSats.ts
@@ -1,17 +1,18 @@
 import { cryptoCurrency } from './api-client';
 
-const DEFAULT_N = 3
+const DEFAULT = 3
+const MAX = 4
 
 
 export const getNSatoshis = (amount: number, randomSatoshis: boolean | number): number => {
   const amountDigits = amount.toString().replace('.', '').length;
   if (randomSatoshis === true) {
-    return Math.min(DEFAULT_N, amountDigits)
+    return Math.min(DEFAULT, amountDigits)
   } else if (randomSatoshis === false) {
     throw new Error("Trying to randomize satoshis when not allowed.")
   }
-  if (randomSatoshis > 8) {
-    throw new Error("Can't have more than 8 randomized satoshis.")
+  if (randomSatoshis > MAX) {
+    randomSatoshis = MAX
   }
   return Math.min(randomSatoshis, amountDigits)
 }

--- a/react/src/util/randomizeSats.ts
+++ b/react/src/util/randomizeSats.ts
@@ -3,23 +3,24 @@ import { cryptoCurrency } from './api-client';
 const DEFAULT_N = 3
 
 
-export const getNSatoshis = (randomSatoshis: boolean | number): number => {
+export const getNSatoshis = (amount: number, randomSatoshis: boolean | number): number => {
+  const amountDigits = amount.toString().replace('.', '').length;
   if (randomSatoshis === true) {
-    return DEFAULT_N
+    return Math.min(DEFAULT_N, amountDigits)
   } else if (randomSatoshis === false) {
     throw new Error("Trying to randomize satoshis when not allowed.")
   }
   if (randomSatoshis > 8) {
     throw new Error("Can't have more than 8 randomized satoshis.")
   }
-  return randomSatoshis
+  return Math.min(randomSatoshis, amountDigits)
 }
 
 export const randomizeSatoshis = (amount: number, addressType: cryptoCurrency, randomSatoshis: boolean | number): number => {
   if (amount === 0) {
     return 0;
   }
-  const nSatoshis = getNSatoshis(randomSatoshis)
+  const nSatoshis = getNSatoshis(amount, randomSatoshis)
 
   const random = Math.floor(Math.random() * 10 ** nSatoshis);
   let randomToAdd: number

--- a/react/src/util/randomizeSats.ts
+++ b/react/src/util/randomizeSats.ts
@@ -1,32 +1,42 @@
 import { cryptoCurrency } from './api-client';
-export const randomizeSatoshis = (amount: number, addressType: cryptoCurrency): number => {
+
+const DEFAULT_N = 3
+
+
+export const getNSatoshis = (randomSatoshis: boolean | number): number => {
+  if (randomSatoshis === true) {
+    return DEFAULT_N
+  } else if (randomSatoshis === false) {
+    throw new Error("Trying to randomize satoshis when not allowed.")
+  }
+  if (randomSatoshis > 8) {
+    throw new Error("Can't have more than 8 randomized satoshis.")
+  }
+  return randomSatoshis
+}
+
+export const randomizeSatoshis = (amount: number, addressType: cryptoCurrency, randomSatoshis: boolean | number): number => {
   if (amount === 0) {
     return 0;
   }
-  const date = new Date();
+  const nSatoshis = getNSatoshis(randomSatoshis)
 
-  // 0-99: 10 second window, resets every 16.5 minutes
-  const window =
-    Math.floor((date.getUTCMinutes() * 60 + date.getUTCSeconds()) / 10) % 100;
-  // 0-99: random
-  const random = Math.floor(Math.random() * 100);
+  const random = Math.floor(Math.random() * 10 ** nSatoshis);
   let randomToAdd: number
   let randomizedAmount: number
   let ret: number
   switch (addressType) {
     case 'BCH':
-      randomToAdd = random * 1e-6 + // Two random digits
-        window * 1e-8; // Two digits for the time window
+      randomToAdd = random * 1e-8
       randomizedAmount =
-        Math.max(0, +amount.toFixed(4)) + // zero out the 4 least-significant digits
+        Math.max(0, +amount.toFixed(nSatoshis)) + // zero out the least-significant digits
         randomToAdd
       ret = +randomizedAmount.toFixed(8);
       break
     case 'XEC':
-      randomToAdd = random * 1 + // Two random digits
-        window * 1e-2; // Two digits for the time window
-      randomizedAmount =
-        Math.max(0, +(Math.floor(amount/100) * 100)) + // zero out the 4 least-significant digits
+      randomToAdd = random * 1e-2;
+        const multiplier = 10 ** (nSatoshis - 2)
+        randomizedAmount = Math.max(0, +(Math.floor(amount / multiplier) * multiplier)) + // zero out the least-significant digits
         randomToAdd
       ret = +randomizedAmount.toFixed(2);
       break

--- a/react/src/util/satoshis.ts
+++ b/react/src/util/satoshis.ts
@@ -12,7 +12,7 @@ export type currencyObject = {
 export const getCurrencyObject = (
   amount: number,
   currencyType: currency,
-  randomSatoshis: boolean
+  randomSatoshis: boolean | number
 ): currencyObject => {
   let string = '';
   let float = 0;

--- a/react/src/util/satoshis.ts
+++ b/react/src/util/satoshis.ts
@@ -20,7 +20,7 @@ export const getCurrencyObject = (
   if (currencyType === 'BCH' || currencyType === 'XEC') {
     let newAmount = amount
     if (randomSatoshis) {
-      newAmount = randomizeSatoshis(amount, currencyType)
+      newAmount = randomizeSatoshis(amount, currencyType, randomSatoshis)
     }
     let primaryUnit = new BigNumber(`${newAmount}`);
     if (primaryUnit !== null && primaryUnit.c !== null) {


### PR DESCRIPTION
Related to #281

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Allows random satoshis to be a number.



Test plan
---
Create buttons with different `randomSatoshis` values and check the following behavior:

`false`: no random satoshis
`true`: randomize the last 3 digits
`0`: no random satoshis (same as false)
`1`: randomize the last 1 digit
`2`: randomize the last 2 digits
`3`: randomize the last 3 digits
`4`: randomize the last 4 digits
`> 4`: randomize the last 4 digits

Also, check that if a button amount has fewer significant digits than what is being randomized, the randomSatoshis behaves as the biggest that makes sense to that amount, e.g:
`amount=1.00` and `randomSatoshis=4` should behave the same as if `randomSatoshis=3`, since there are only 3 digits that could be randomized in the amount.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
