### PR TITLE
Add widget style rule

### DIFF
--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -113,7 +113,7 @@ const useStyles = makeStyles({
   footer: ({ theme }: StyleProps) => ({
     fontSize: '0.6rem !important',
     color: `${theme.palette.tertiary} !important`,
-    fontWeight: 'normal !important',
+    fontWeight: 'normal',
   }),
 });
 
@@ -590,6 +590,7 @@ export const Widget: React.FC<WidgetProps> = props => {
                 target="_blank"
                 rel="noopener"
                 className={classes.footer}
+                style={{ fontWeight: 'normal' }}
               >
                 Powered by PayButton.org
               </Link>

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -113,6 +113,7 @@ const useStyles = makeStyles({
   footer: ({ theme }: StyleProps) => ({
     fontSize: '0.6rem !important',
     color: `${theme.palette.tertiary} !important`,
+    fontWeight: 'normal',
   }),
 });
 
@@ -588,8 +589,7 @@ export const Widget: React.FC<WidgetProps> = props => {
                 href="https://paybutton.org"
                 target="_blank"
                 rel="noopener"
-                className="{classes.footer}"
-                style={{ color: '#3f51b566', fontWeight: 'normal', fontSize: '0.6rem' }}
+                className={classes.footer}
               >
                 Powered by PayButton.org
               </Link>

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -113,7 +113,7 @@ const useStyles = makeStyles({
   footer: ({ theme }: StyleProps) => ({
     fontSize: '0.6rem !important',
     color: `${theme.palette.tertiary} !important`,
-    fontWeight: 'normal',
+    fontWeight: 'normal !important',
   }),
 });
 

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -110,9 +110,9 @@ const useStyles = makeStyles({
   spinner: ({ theme }: StyleProps) => ({
     color: `${theme.palette.primary} !important`,
   }),
-  footer: ({ theme }: StyleProps) => ({
+  footer: () => ({
     fontSize: '0.6rem !important',
-    color: `${theme.palette.tertiary} !important`,
+    color: '#3f51b566 !important',
     fontWeight: 'normal',
   }),
 });
@@ -590,7 +590,6 @@ export const Widget: React.FC<WidgetProps> = props => {
                 target="_blank"
                 rel="noopener"
                 className={classes.footer}
-                style={{ fontWeight: 'normal' }}
               >
                 Powered by PayButton.org
               </Link>

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -92,7 +92,7 @@ const useStyles = makeStyles({
     },
   }),
   copyTextContainer: ({ loading }: StyleProps) => ({
-    display: loading ? 'none !important' : 'block !important',
+    display: loading ? 'none' : 'block',
     background: '#ffffffcc !important',
     padding: '0 0.15rem 0.15rem 0 !important',
   }),

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -589,7 +589,7 @@ export const Widget: React.FC<WidgetProps> = props => {
                 target="_blank"
                 rel="noopener"
                 className="{classes.footer}"
-                style={{ color: '#3f51b566', fontWeight: 'normal' }}
+                style={{ color: '#3f51b566', fontWeight: 'normal', fontSize: '0.6rem' }}
               >
                 Powered by PayButton.org
               </Link>


### PR DESCRIPTION
Related to #290

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fixing the font-size for the widget footer not being specified


Test plan
---
Preview the widget and check the footer link is the right size even if other css rules trying to target it 

for example try adding  <style>
      body a {
        font-size: 44px !important;
        color: red !important;
      }
    </style>

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
