### PR TITLE
[#141] UI: Add amount to click to copy

### DIFF
--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -347,10 +347,16 @@ export const Widget: React.FC<WidgetProps> = props => {
   const handleQrCodeClick = (): void => {
     if (disabled || to === undefined) return;
     const address = to;
+    let thisAmount: number | undefined
+    if (convertedCurrencyObj) {
+      thisAmount = convertedCurrencyObj.float
+    } else {
+      thisAmount = (currencyObject ? currencyObject.float : undefined)
+    }
     if (isValidCashAddress(address)) {
       prefixedAddress = `bitcoincash:${address.replace(/^.*:/, '')}`;
     } else {
-      prefixedAddress = `ecash:${address.replace(/^.*:/, '')}`;
+      prefixedAddress = `ecash:${address.replace(/^.*:/, '')}${thisAmount ? `?amount=${thisAmount}` : ''}`;
     }
     if (!copy(prefixedAddress)) return;
     setCopied(true);


### PR DESCRIPTION
Related to #141

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
This should add the amount to the copied address when you click the qr code
It should also use the converted XEC amount if a non-xec currency is specified 

Test plan
---
Build the package and test out a widget and a button with and without an amount specified, and try changing the currency as well
Then try pasting the copied value into different wallets and see if the amount field is carried through correctly 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
