### PR TITLE
[#306] fix: no loading if no goal bar to be loaded

### DIFF
--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -492,7 +492,7 @@ export const Widget: React.FC<WidgetProps> = props => {
           px={3}
           pt={2}
         >
-          {loading ? (
+          {loading && shouldDisplayGoal ? (
             <Typography
               className={classes.text}
               style={{ margin: '10px auto 20px' }}


### PR DESCRIPTION
Related to #306

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fix UI bug where the loading circle would appear on the bar even if there was no bar to be loaded (when there is no goal)



<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
