### PR TITLE
fix: only move files if they exist

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build": "microbundle --jsx React.createElement --format modern,cjs",
-    "postbuild": "cp -rf dist/react/src/* dist/",
+    "postbuild": "cp -rf dist/react/src/* dist/ || true",
     "lint": "eslint 'src/**/*.{ts,tsx}' --fix",
     "prettier": "prettier --write 'src/**/*.ts'",
     "dev": "concurrently npm:watch npm:storybook",


### PR DESCRIPTION


<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Solves issue where if `dist/src`  was not created the build would error.


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
