### PR TITLE
[#289] fix: widget container renderization

### DIFF
--- a/paybutton/src/index.tsx
+++ b/paybutton/src/index.tsx
@@ -2,7 +2,6 @@ import camelcase from 'camelcase';
 import { PayButton, PayButtonProps, PaymentDialog, PaymentDialogProps, Widget, WidgetProps } from 'paybutton';
 import { h } from 'preact';
 import { render } from 'preact/compat';
-import WidgetContainer from 'paybutton/dist/components/Widget/WidgetContainer';
 
 declare global {
   interface Window {
@@ -239,7 +238,7 @@ export default {
   renderWidget: (el: HTMLElement, props: WidgetProps) => {
     if (el !== null) {
       validateJSProps(props)
-      render(<WidgetContainer {...props} />, el)
+      render(<Widget {...props} />, el)
     }
   },
   openDialog: (props: PaymentDialogProps) => openDialog(props)

--- a/react/package.json
+++ b/react/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build": "microbundle --jsx React.createElement --format modern,cjs",
-    "postbuild": "cp -rf dist/react/src/* dist/",
+    "postbuild": "cp -rf dist/react/src/* dist/ || true",
     "lint": "eslint 'src/**/*.{ts,tsx}' --fix",
     "prettier": "prettier --write 'src/**/*.ts'",
     "dev": "concurrently npm:watch npm:storybook",

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -325,7 +325,7 @@ export const Widget: React.FC<WidgetProps> = props => {
         setUrl(url);
       }
     }
-  }, [currencyObject, price, amount]);
+  }, [to, currencyObject, price, amount]);
 
   const handleButtonClick = () => {
     if (addressType === 'XEC'){


### PR DESCRIPTION
Related to #289


Depends on
---
- [x] #310



<!-- Non-technical -->
Description
---
Fixed issue where Widgets QR codes  did not get rerendered if the address  changed.


Test plan
---
Use the function `PayButton.renderWidget` to rerender an HTML element and make sure it works.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
