### PR TITLE
Fix: Update amount in widget React 

### DIFF
--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -416,6 +416,10 @@ export const Widget: React.FC<WidgetProps> = props => {
     }
   };
 
+  useEffect(() => { 
+    setThisAmount(props.amount);
+  }, [props.amount]);
+
   useEffect(() => {
     if (totalReceived !== undefined) {
       const progress = getCurrencyObject(totalReceived, currency, false);


### PR DESCRIPTION
Related to #

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Adding a useEffect hook to listen for props.amount change so the amount and widget get updated when the amount changes 


Test plan
---
Build and test it out. Check the amount changes when updated, especially in a react build where the amount is a passed state variable. Can see https://ecash.land/ as an example with this patch

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
