### PR TITLE
[#317] fix: address change subscription

### DIFF
--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -199,7 +199,7 @@ export const Widget: React.FC<WidgetProps> = props => {
         query: { addresses: [to] }
       })
       if (socket !== undefined) {
-        const ret = socket.disconnect()
+        socket.disconnect()
       }
       setSocket(newSocket)
       setListener(newSocket, setNewTxs)

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -25,7 +25,7 @@ import BarChart from '../BarChart/BarChart';
 import { getCurrencyObject, currencyObject } from '../../util/satoshis';
 import { currency, getAddressBalance, getAddressDetails, isFiat, setListener, Transaction, getCashtabProviderStatus, cryptoCurrency } from '../../util/api-client';
 import PencilIcon from '../../assets/edit-pencil';
-import io from 'socket.io-client'
+import io, { Socket } from 'socket.io-client'
 
 type QRCodeProps = BaseQRCodeProps & { renderAs: 'svg' };
 
@@ -143,6 +143,7 @@ export const Widget: React.FC<WidgetProps> = props => {
   const [errorMsg, setErrorMsg] = useState('');
   const [goalText, setGoalText] = useState('');
   const [goalPercent, setGoalPercent] = useState(0);
+  const [socket, setSocket] = useState<Socket | undefined>(undefined)
   const [addressType, setAddressType] = useState<cryptoCurrency>();
   const [convertedCurrencyObj, setConvertedCurrencyObj] = useState<currencyObject|null>();
   const price = props.price;
@@ -193,12 +194,16 @@ export const Widget: React.FC<WidgetProps> = props => {
   useEffect(() => {
     (async (): Promise<void> => {
       void await getAddressDetails(to, apiBaseUrl);
-      const socket = io(`${wsBaseUrl ?? config.wsBaseUrl}/addresses`, {
+      const newSocket = io(`${wsBaseUrl ?? config.wsBaseUrl}/addresses`, {
         query: { addresses: [to] }
       })
-      setListener(socket, setNewTxs)
+      if (socket !== undefined) {
+        socket.offAny()
+      }
+      setSocket(newSocket)
+      setListener(newSocket, setNewTxs)
     })();
-  }, [])
+  }, [to])
 
   useEffect(() => {
     (async (): Promise<void> => {
@@ -407,7 +412,7 @@ export const Widget: React.FC<WidgetProps> = props => {
     }
   };
 
-  useEffect(() => { 
+  useEffect(() => {
     setThisAmount(props.amount);
   }, [props.amount]);
 

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -7,9 +7,9 @@ import {
   TextField,
   Grid,
 } from '@material-ui/core';
+import React, { useEffect, useMemo, useState } from 'react';
 import copy from 'copy-to-clipboard';
 import QRCode, { BaseQRCodeProps } from 'qrcode.react';
-import React, { useEffect, useMemo, useState } from 'react';
 import config from '../../paybutton-config.json'
 
 import { Theme, ThemeName, ThemeProvider, useTheme } from '../../themes';
@@ -193,12 +193,13 @@ export const Widget: React.FC<WidgetProps> = props => {
 
   useEffect(() => {
     (async (): Promise<void> => {
+      // subscribes address on paybutton server
       void await getAddressDetails(to, apiBaseUrl);
       const newSocket = io(`${wsBaseUrl ?? config.wsBaseUrl}/addresses`, {
         query: { addresses: [to] }
       })
       if (socket !== undefined) {
-        socket.offAny()
+        const ret = socket.disconnect()
       }
       setSocket(newSocket)
       setListener(newSocket, setNewTxs)

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -147,7 +147,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
         if (!hideToasts)
           // TODO: This assumes only bch
           enqueueSnackbar(
-            `${successText} | Received ${receivedAmount} ${currencyTicker}`,
+            `${successText ? successText + ' | ' : ''}Received ${receivedAmount} ${currencyTicker}`,
             snackbarOptions,
           );
 


### PR DESCRIPTION
Related to #317

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Solves #317 


Test plan
---
Make sure that after changing the address of a widget:
1. The old address, when receiving transactions, doesn't trigger `onSuccess`, `onTransaction`, alert, etc.
2. The new address does.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
