### PR TITLE
[#302] feat: op return parameter

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -635,6 +635,35 @@ onClose = successCallback
 
 <!-- tabs:end -->
 
+## op-return
+
+> **The ‘op-return’ parameter specifies the custom message that will be send with the transaction.
+
+?> This parameter is optional. Default value is empty. Possible values are any string with up to 68 bytes.
+
+**Example:**
+<!-- tabs:start -->
+
+#### ** HTML **
+
+```html
+on-close="myCustomMessage"
+```
+
+#### ** JavaScript **
+
+```javascript
+onClose: "myCustomMessage"
+```
+
+#### ** React **
+
+```react
+onClose = "myCustomMessage"
+```
+
+<!-- tabs:end -->
+
 ## random-satoshis
 
 > **The ‘random-satoshis’ parameter specifies whether to randomize the last few digits of the payment amount so that it’s unlikely that a payment made by one person will trigger the onSuccess callback of another who has the payment screen open at the same time.**

--- a/docs/zh-cn/README.md
+++ b/docs/zh-cn/README.md
@@ -633,6 +633,36 @@ onClose = successCallback
 
 <!-- tabs:end -->
 
+
+## op-return
+
+> **‘op-return’参数指定将与交易一起发送的自定义消息。**
+
+?> 此参数是可选的。默认值为空。可能的值为任何最多68字节的字符串。
+
+<!-- tabs:start -->
+
+#### ** HTML **
+
+```html
+op-return=""
+```
+
+#### ** JavaScript **
+
+```javascript
+opReturn: ''
+```
+
+#### ** React **
+
+```react
+opReturn = ""
+```
+
+<!-- tabs:end -->
+
+
 ## random-satoshis
 
 > **参数"random-satoshis"用来定义是否将付款金额的最后几位随机化，因此当一个人进行付款时不太可能触发回调 onSuccess的同时另一个人正打开付款屏幕。**

--- a/docs/zh-tw/README.md
+++ b/docs/zh-tw/README.md
@@ -633,6 +633,36 @@ onClose = successCallback
 
 <!-- tabs:end -->
 
+
+## op-return
+
+> **‘op-return’參數指定將與交易一起發送的自定義消息。**
+
+?> 此參數是可選的。默認值為空。可能的值為任何最多68字節的字符串。
+
+<!-- tabs:start -->
+
+#### ** HTML **
+
+```html
+op-return=""
+```
+
+#### ** JavaScript **
+
+```javascript
+opReturn: ''
+```
+
+#### ** React **
+
+```react
+opReturn = ""
+```
+
+<!-- tabs:end -->
+
+
 ## random-satoshis
 
 > **參數"random-satoshis"用來定義是否將付款金額的最後幾位隨機化，因此當一個人進行付款時不太可能觸發回呼onSuccess的同時另一個人正打開付款螢幕。**

--- a/paybutton/dev/advanced.html
+++ b/paybutton/dev/advanced.html
@@ -59,6 +59,7 @@
         },
         animation: 'invert',
         successText: 'Purchase Complete!',
+        opReturn: 'customMessage',
         onSuccess: mySuccessFunction,
         onTransaction: myTransactionFunction,
         onOpen: myOpenFunction,

--- a/paybutton/src/index.tsx
+++ b/paybutton/src/index.tsx
@@ -82,6 +82,7 @@ const allowedProps = [
   'theme',
   'text',
   'to',
+  'opReturn',
   'disabled',
   'goalAmount',
   'editable',

--- a/react/src/components/PayButton/PayButton.tsx
+++ b/react/src/components/PayButton/PayButton.tsx
@@ -11,6 +11,7 @@ import BigNumber from 'bignumber.js';
 export interface PayButtonProps extends ButtonProps {
   to: string;
   amount?: number | string;
+  opReturn?: string;
   currency?: currency;
   theme?: ThemeName | Theme;
   text?: string;
@@ -39,6 +40,7 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
 
   const {
     to,
+    opReturn,
     currency,
     text,
     hoverText,
@@ -130,6 +132,7 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
         disableScrollLock
         to={to}
         amount={amount}
+        opReturn={opReturn}
         setAmount={setAmount}
         currencyObj={currencyObj}
         setCurrencyObj={setCurrencyObj}

--- a/react/src/components/PaymentDialog/PaymentDialog.tsx
+++ b/react/src/components/PaymentDialog/PaymentDialog.tsx
@@ -13,6 +13,7 @@ export interface PaymentDialogProps extends ButtonProps {
   to: string;
   amount?: number | string;
   setAmount: Function;
+  opReturn?: string;
   currency?: currency;
   currencyObj?: currencyObject;
   setCurrencyObj: Function;
@@ -44,6 +45,7 @@ export const PaymentDialog = (
     to,
     amount,
     setAmount,
+    opReturn,
     currency,
     currencyObj,
     setCurrencyObj,
@@ -110,6 +112,7 @@ export const PaymentDialog = (
           active={dialogOpen}
           to={to}
           amount={cleanAmount}
+          opReturn={opReturn}
           setAmount={setAmount}
           currencyObj={currencyObj}
           setCurrencyObj={setCurrencyObj}

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -26,6 +26,7 @@ import { getCurrencyObject, currencyObject } from '../../util/satoshis';
 import { currency, getAddressBalance, getAddressDetails, isFiat, setListener, Transaction, getCashtabProviderStatus, cryptoCurrency } from '../../util/api-client';
 import PencilIcon from '../../assets/edit-pencil';
 import io, { Socket } from 'socket.io-client'
+import { parseOpReturn } from '../../util/opReturn';
 
 type QRCodeProps = BaseQRCodeProps & { renderAs: 'svg' };
 
@@ -152,7 +153,7 @@ export const Widget: React.FC<WidgetProps> = props => {
   const [userEditedAmount, setUserEditedAmount] = useState<currencyObject>();
   const [text, setText] = useState('Send any amount of BCH');
   const [widgetButtonText, setWidgetButtonText] = useState('Send Payment');
-  const [opReturn, setOpReturn] = useState(props.opReturn);
+  const [opReturn, setOpReturn] = useState<string | undefined>();
 
   const theme = useTheme(props.theme, isValidXecAddress(to));
   const classes = useStyles({ success, loading, theme });
@@ -428,7 +429,13 @@ export const Widget: React.FC<WidgetProps> = props => {
   };
 
   useEffect(() => {
-    setOpReturn(props.opReturn);
+    try {
+      setOpReturn(
+        parseOpReturn(props.opReturn)
+      );
+    } catch (err) {
+      setErrorMsg(err.message)
+    }
   }, [props.opReturn]);
 
   useEffect(() => {

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -288,7 +288,7 @@ export const Widget: React.FC<WidgetProps> = props => {
     }
 
     if (opReturn !== undefined && opReturn !== '') {
-      query.push(`op_return=paybutton\$${opReturn}`)
+      query.push(`op_return=${opReturn}`)
     }
 
     url = prefixedAddress + (query.length ? `?${query.join('&')}` : '');
@@ -376,9 +376,9 @@ export const Widget: React.FC<WidgetProps> = props => {
     }
     if (opReturn !== undefined && opReturn !== '') {
       if (prefixedAddress.includes('?')) {
-        prefixedAddress += `&op_return=paybutton\$${opReturn}`
+        prefixedAddress += `&op_return=${opReturn}`
       } else {
-        prefixedAddress += `?op_return=paybutton\$${opReturn}`
+        prefixedAddress += `?op_return=${opReturn}`
       }
     }
     if (!copy(prefixedAddress)) return;

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -33,6 +33,7 @@ export interface WidgetProps {
   to: string;
   amount?: number | null | string;
   setAmount?: Function;
+  opReturn?: string;
   text?: string;
   ButtonComponent?: React.ComponentType;
   success: boolean;
@@ -151,6 +152,7 @@ export const Widget: React.FC<WidgetProps> = props => {
   const [userEditedAmount, setUserEditedAmount] = useState<currencyObject>();
   const [text, setText] = useState('Send any amount of BCH');
   const [widgetButtonText, setWidgetButtonText] = useState('Send Payment');
+  const [opReturn, setOpReturn] = useState(props.opReturn);
 
   const theme = useTheme(props.theme, isValidXecAddress(to));
   const classes = useStyles({ success, loading, theme });
@@ -283,6 +285,11 @@ export const Widget: React.FC<WidgetProps> = props => {
         prefixedAddress = `ecash:${address.replace(/^.*:/, '')}`;
         break;
     }
+
+    if (opReturn !== undefined && opReturn !== '') {
+      query.push(`op_return=paybutton\$${opReturn}`)
+    }
+
     url = prefixedAddress + (query.length ? `?${query.join('&')}` : '');
 
     if (thisCurrencyObject && hasPrice) {
@@ -315,7 +322,7 @@ export const Widget: React.FC<WidgetProps> = props => {
         setUrl(url);
       }
     }
-  }, [to, thisCurrencyObject, price, thisAmount]);
+  }, [to, thisCurrencyObject, price, thisAmount, opReturn]);
 
   const handleButtonClick = () => {
     if (addressType === 'XEC'){
@@ -366,6 +373,13 @@ export const Widget: React.FC<WidgetProps> = props => {
     } else {
       prefixedAddress = `ecash:${address.replace(/^.*:/, '')}${thisAmount ? `?amount=${thisAmount}` : ''}`;
     }
+    if (opReturn !== undefined && opReturn !== '') {
+      if (prefixedAddress.includes('?')) {
+        prefixedAddress += `&op_return=paybutton\$${opReturn}`
+      } else {
+        prefixedAddress += `?op_return=paybutton\$${opReturn}`
+      }
+    }
     if (!copy(prefixedAddress)) return;
     setCopied(true);
     setRecentlyCopied(true);
@@ -412,6 +426,10 @@ export const Widget: React.FC<WidgetProps> = props => {
       props.setAmount(amount)
     }
   };
+
+  useEffect(() => {
+    setOpReturn(props.opReturn);
+  }, [props.opReturn]);
 
   useEffect(() => {
     setThisAmount(props.amount);

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -21,12 +21,10 @@ import Widget, { WidgetProps } from './Widget';
 import BigNumber from 'bignumber.js';
 
 export interface WidgetContainerProps
-  extends Omit<
-    WidgetProps,
-    'success' | 'setNewTxs' | 'setCurrencyObject'
-  > {
+  extends Omit<WidgetProps, 'success' | 'setNewTxs' | 'setCurrencyObject'> {
   active?: boolean;
   amount?: number;
+  opReturn?: string;
   currency?: currency;
   currencyObj?: currencyObject;
   setCurrencyObj: Function;
@@ -76,6 +74,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
     let {
       active = true,
       to,
+      opReturn,
       amount,
       setAmount,
       setCurrencyObj,
@@ -147,7 +146,9 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
         if (!hideToasts)
           // TODO: This assumes only bch
           enqueueSnackbar(
-            `${successText ? successText + ' | ' : ''}Received ${receivedAmount} ${currencyTicker}`,
+            `${
+              successText ? successText + ' | ' : ''
+            }Received ${receivedAmount} ${currencyTicker}`,
             snackbarOptions,
           );
 
@@ -221,6 +222,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = withSnackbar(
           {...widgetProps}
           amount={amount}
           setAmount={setAmount}
+          opReturn={opReturn}
           goalAmount={goalAmount}
           currency={currency}
           animation={animation}

--- a/react/src/util/opReturn.ts
+++ b/react/src/util/opReturn.ts
@@ -1,0 +1,10 @@
+export const OP_RETURN_PREFIX = 'paybutton$'
+
+export function parseOpReturn(opReturn: string | undefined): string | undefined {
+  if (opReturn === undefined) return undefined
+  const bytesQuantity = (new Blob([opReturn])).size
+  if (bytesQuantity > 70) {
+    throw new Error(`Maximum 70 byte size exceeded: ${bytesQuantity}`)
+  }
+  return OPRETURN_PREFIX + opReturn
+}

--- a/react/src/util/opReturn.ts
+++ b/react/src/util/opReturn.ts
@@ -1,10 +1,20 @@
-export const OP_RETURN_PREFIX = 'paybutton$'
+export const OP_RETURN_PREFIX = 'paybutton$';
 
-export function parseOpReturn(opReturn: string | undefined): string | undefined {
-  if (opReturn === undefined) return undefined
-  const bytesQuantity = (new Blob([opReturn])).size
+export function stringToHex(str: string): string {
+  return str
+    .split('')
+    .map(c => c.charCodeAt(0).toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export function parseOpReturn(
+  opReturn: string | undefined,
+): string | undefined {
+  if (opReturn === undefined) return undefined;
+  const bytesQuantity = new Blob([opReturn]).size;
+
   if (bytesQuantity > 70) {
-    throw new Error(`Maximum 70 byte size exceeded: ${bytesQuantity}`)
+    throw new Error(`Maximum 70 byte size exceeded: ${bytesQuantity}`);
   }
-  return OPRETURN_PREFIX + opReturn
+  return OP_RETURN_PREFIX + opReturn;
 }


### PR DESCRIPTION
Related to #302 



<!-- Non-technical -->
Description
---
Allows for a `op-return` parameter.


Test plan
---



This parameter will be prefixed by `paybutton$` and then embedded in the copy + paste URL — CashTab still not supported.

Then, when pasted into ElectrumABC, this should show something like `paybutton$the-data-you-inputted-in-the-op-return-props-attribute`. 







<!-- Uncomment below to add any remarks, technical or not -->
 
Remarks
---

Parsing of this data will be implemented in a next PR