### PR TITLE
fix: catch api error

### DIFF
--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -213,6 +213,7 @@ export const Widget: React.FC<WidgetProps> = props => {
     (async (): Promise<void> => {
       const balance = await getAddressBalance(to, apiBaseUrl);
       setTotalReceived(balance);
+      setLoading(false);
     })();
   }, [newTxs]);
 

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -31,9 +31,15 @@ export const setListener = (socket: Socket, setNewTxs: Function): void => {
 export const getAddressBalance = async (
   address: string,
   rootUrl = config.apiBaseUrl,
-): Promise<number> => {
-  const res = await axios.get(`${rootUrl}/address/balance/${address}`);
-  return isNaN(res.data) ? null : res.data;
+): Promise<number | undefined> => {
+  try {
+    const res = await axios.get(`${rootUrl}/address/balance/${address}`);
+
+    return isNaN(res.data) ? null : res.data;
+  } catch (error) {
+    return;
+  }
+ 
 };
 
 export const getUTXOs = async (


### PR DESCRIPTION
Related to #331

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
This issue was happening because the app did not set the load to false when the api call fails, so in this fix we 
add error handling and set the loader to false to fix qrcode not showing up 


Test plan
---

- Run story book using this steps from the [docs](https://docs.paybutton.org/#/?id=developer-quick-start:~:text=of%20the%20project.-,Developer%20Quick%20Start,-Build)

```
> docker-compose up
> Wait for storybook to initialize.
> Open http://localhost:6006.
```

- Open storybook 
- Go to `Paybutton` 
- Set `to` option to a valid BCH address like this one  `bitcoincash:qrmm7edwuj4jf7tnvygjyztyy0a0qxvl7q9ayphulp` 
- Open the Payment dialog by clicking in the `Paybutton`  and check if the `BCH` `Qrcode`  is showing up as expected


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
