### PR TITLE
fix: notistack version

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -87,7 +87,7 @@
     "bignumber.js": "9.0.2",
     "copy-to-clipboard": "3.3.3",
     "lodash": "4.17.21",
-    "notistack": "3.0.1",
+    "notistack": "1.0.10",
     "qrcode.react": "1.0.1",
     "react-jss": "10.10.0",
     "socket.io-client": "4.7.4",


### PR DESCRIPTION
Related to #346


<!-- Non-technical -->
Description
---

This PR adjusts the version of `notistack` to mach material-ui v4, it fixes the font in the toast


Test plan
---
Open the project, run the command `yarn clean:build` get the build and test if the toast has the correct font 


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
