### PR TITLE
[#302] feat: payment id on components

### DIFF
--- a/paybutton/src/index.tsx
+++ b/paybutton/src/index.tsx
@@ -110,9 +110,9 @@ function renderDialogButton(dialogbuttonExists: boolean): void {
 function openDialog(props: PaymentDialogProps): void {
   const container = document.createElement('div');
   document.body.appendChild(container);
-  const onClose = (paymentId?: string, success?: boolean) => {
+  const onClose = (success?: boolean, paymentId?:string) => {
     if (props.onClose !== undefined) {
-      props.onClose(paymentId, success)
+      props.onClose(success, paymentId)
     }
     container.remove()
   }

--- a/paybutton/src/index.tsx
+++ b/paybutton/src/index.tsx
@@ -110,9 +110,9 @@ function renderDialogButton(dialogbuttonExists: boolean): void {
 function openDialog(props: PaymentDialogProps): void {
   const container = document.createElement('div');
   document.body.appendChild(container);
-  const onClose = (success?: boolean) => {
+  const onClose = (paymentId?: string, success?: boolean) => {
     if (props.onClose !== undefined) {
-      props.onClose(success)
+      props.onClose(paymentId, success)
     }
     container.remove()
   }

--- a/paybutton/yarn.lock
+++ b/paybutton/yarn.lock
@@ -1641,11 +1641,6 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-goober@^2.0.33:
-  version "2.1.14"
-  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.14.tgz#4a5c94fc34dc086a8e6035360ae1800005135acd"
-  integrity sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==
-
 graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
@@ -2590,13 +2585,13 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-notistack@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/notistack/-/notistack-3.0.1.tgz#daf59888ab7e2c30a1fa8f71f9cba2978773236e"
-  integrity sha512-ntVZXXgSQH5WYfyU+3HfcXuKaapzAJ8fBLQ/G618rn3yvSzEbnOB8ZSOwhX+dAORy/lw+GC2N061JA0+gYWTVA==
+notistack@1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/notistack/-/notistack-1.0.10.tgz#8db90830034383467a04184f1fa8ff77f4fc58a5"
+  integrity sha512-z0y4jJaVtOoH3kc3GtNUlhNTY+5LE04QDeLVujX3VPhhzg67zw055mZjrBF+nzpv3V9aiPNph1EgRU4+t8kQTQ==
   dependencies:
     clsx "^1.1.0"
-    goober "^2.0.33"
+    hoist-non-react-statics "^3.3.0"
 
 npm-run-path@^4.0.1:
   version "4.0.1"

--- a/react/src/components/PayButton/PayButton.tsx
+++ b/react/src/components/PayButton/PayButton.tsx
@@ -28,9 +28,9 @@ export interface PayButtonProps extends ButtonProps {
   onSuccess?: (txid: string, amount: BigNumber) => void;
   onTransaction?: (txid: string, amount: BigNumber) => void;
   onOpen?: (
-    paymentId: string,
     expectedAmount?: number | string,
     address?: string,
+    paymentId?: string,
   ) => void;
   onClose?: (paymentId?: string, success?: boolean) => void;
   wsBaseUrl?: string;
@@ -68,7 +68,7 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
   } = Object.assign({}, PayButton.defaultProps, props);
 
   const handleButtonClick = (): void => {
-    if (onOpen !== undefined) onOpen(paymentId, amount, to);
+    if (onOpen !== undefined) onOpen(amount, to, paymentId);
     setDialogOpen(true);
   };
   const handleCloseDialog = (paymentId?: string, success?: boolean): void => {

--- a/react/src/components/PayButton/PayButton.tsx
+++ b/react/src/components/PayButton/PayButton.tsx
@@ -28,7 +28,7 @@ export interface PayButtonProps extends ButtonProps {
   onSuccess?: (txid: string, amount: BigNumber) => void;
   onTransaction?: (txid: string, amount: BigNumber) => void;
   onOpen?: (
-    paymentId?: string,
+    paymentId: string,
     expectedAmount?: number | string,
     address?: string,
   ) => void;

--- a/react/src/components/PayButton/PayButton.tsx
+++ b/react/src/components/PayButton/PayButton.tsx
@@ -7,6 +7,7 @@ import { PaymentDialog } from '../PaymentDialog/PaymentDialog';
 import { isValidCashAddress, isValidXecAddress } from '../../util/address';
 import { currencyObject, getCurrencyObject } from '../../util/satoshis';
 import BigNumber from 'bignumber.js';
+import { generatePaymentId } from '../../util/opReturn';
 
 export interface PayButtonProps extends ButtonProps {
   to: string;
@@ -26,8 +27,12 @@ export interface PayButtonProps extends ButtonProps {
   editable?: boolean;
   onSuccess?: (txid: string, amount: BigNumber) => void;
   onTransaction?: (txid: string, amount: BigNumber) => void;
-  onOpen?: (expectedAmount?: number | string, address?: string) => void;
-  onClose?: (success?: boolean) => void;
+  onOpen?: (
+    paymentId?: string,
+    expectedAmount?: number | string,
+    address?: string,
+  ) => void;
+  onClose?: (paymentId?: string, success?: boolean) => void;
   wsBaseUrl?: string;
   apiBaseUrl?: string;
 }
@@ -37,6 +42,7 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
   const [disabled, setDisabled] = useState(false);
   const [errorMsg, setErrorMsg] = useState('');
   const [amount, setAmount] = useState(props.amount);
+  const [paymentId] = useState(generatePaymentId(8));
   const [currencyObj, setCurrencyObj] = useState<currencyObject | undefined>();
 
   const {
@@ -62,11 +68,11 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
   } = Object.assign({}, PayButton.defaultProps, props);
 
   const handleButtonClick = (): void => {
-    if (onOpen !== undefined) onOpen(amount, to);
+    if (onOpen !== undefined) onOpen(paymentId, amount, to);
     setDialogOpen(true);
   };
-  const handleCloseDialog = (success?: boolean): void => {
-    if (onClose !== undefined) onClose(success);
+  const handleCloseDialog = (paymentId?: string, success?: boolean): void => {
+    if (onClose !== undefined) onClose(paymentId, success);
     setDialogOpen(false);
   };
 
@@ -135,6 +141,7 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
         to={to ?? ''}
         amount={amount}
         opReturn={opReturn}
+        paymentId={paymentId}
         disablePaymentId={disablePaymentId}
         setAmount={setAmount}
         currencyObj={currencyObj}

--- a/react/src/components/PayButton/PayButton.tsx
+++ b/react/src/components/PayButton/PayButton.tsx
@@ -32,7 +32,7 @@ export interface PayButtonProps extends ButtonProps {
     address?: string,
     paymentId?: string,
   ) => void;
-  onClose?: (paymentId?: string, success?: boolean) => void;
+  onClose?: (success?: boolean, paymentId?:string) => void;
   wsBaseUrl?: string;
   apiBaseUrl?: string;
 }
@@ -71,8 +71,8 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
     if (onOpen !== undefined) onOpen(amount, to, paymentId);
     setDialogOpen(true);
   };
-  const handleCloseDialog = (paymentId?: string, success?: boolean): void => {
-    if (onClose !== undefined) onClose(paymentId, success);
+  const handleCloseDialog = (success?: boolean, paymentId?: string): void => {
+    if (onClose !== undefined) onClose(success, paymentId);
     setDialogOpen(false);
   };
 

--- a/react/src/components/PaymentDialog/PaymentDialog.tsx
+++ b/react/src/components/PaymentDialog/PaymentDialog.tsx
@@ -30,7 +30,7 @@ export interface PaymentDialogProps extends ButtonProps {
   disableScrollLock?: boolean;
   active?: boolean;
   container?: HTMLElement;
-  onClose?: (paymentId?: string, success?: boolean) => void;
+  onClose?: (success?: boolean, paymentId?: string) => void;
   onSuccess?: (txid: string, amount: BigNumber) => void;
   onTransaction?: (txid: string, amount: BigNumber) => void;
   wsBaseUrl?: string;
@@ -70,7 +70,7 @@ export const PaymentDialog = (
   } = Object.assign({}, PaymentDialog.defaultProps, props);
 
   const handleWidgetClose = (): void => {
-    if (onClose) onClose(paymentId, success);
+    if (onClose) onClose(success, paymentId);
     setSuccess(false);
   };
   const handleSuccess = (txid: string, amount: BigNumber): void => {

--- a/react/src/components/PaymentDialog/PaymentDialog.tsx
+++ b/react/src/components/PaymentDialog/PaymentDialog.tsx
@@ -14,6 +14,7 @@ export interface PaymentDialogProps extends ButtonProps {
   amount?: number | string;
   setAmount: Function;
   opReturn?: string;
+  paymentId?: string;
   disablePaymentId?: boolean;
   currency?: currency;
   currencyObj?: currencyObject;
@@ -29,7 +30,7 @@ export interface PaymentDialogProps extends ButtonProps {
   disableScrollLock?: boolean;
   active?: boolean;
   container?: HTMLElement;
-  onClose?: (success?: boolean) => void;
+  onClose?: (paymentId?: string, success?: boolean) => void;
   onSuccess?: (txid: string, amount: BigNumber) => void;
   onTransaction?: (txid: string, amount: BigNumber) => void;
   wsBaseUrl?: string;
@@ -47,6 +48,7 @@ export const PaymentDialog = (
     amount,
     setAmount,
     opReturn,
+    paymentId,
     disablePaymentId,
     currency,
     currencyObj,
@@ -68,7 +70,7 @@ export const PaymentDialog = (
   } = Object.assign({}, PaymentDialog.defaultProps, props);
 
   const handleWidgetClose = (): void => {
-    if (onClose) onClose(success);
+    if (onClose) onClose(paymentId, success);
     setSuccess(false);
   };
   const handleSuccess = (txid: string, amount: BigNumber): void => {
@@ -115,6 +117,7 @@ export const PaymentDialog = (
           to={to}
           amount={cleanAmount}
           opReturn={opReturn}
+          paymentId={paymentId}
           disablePaymentId={disablePaymentId}
           setAmount={setAmount}
           currencyObj={currencyObj}

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -34,7 +34,7 @@ import {
   cryptoCurrency,
 } from '../../util/api-client';
 import PencilIcon from '../../assets/edit-pencil';
-import io, { Socket } from 'socket.io-client'
+import io, { Socket } from 'socket.io-client';
 import { encodeOpReturnProps } from '../../util/opReturn';
 
 type QRCodeProps = BaseQRCodeProps & { renderAs: 'svg' };
@@ -44,6 +44,7 @@ export interface WidgetProps {
   amount?: number | null | string;
   setAmount?: Function;
   opReturn?: string;
+  paymentId?: string;
   disablePaymentId?: boolean;
   text?: string;
   ButtonComponent?: React.ComponentType;
@@ -133,6 +134,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
     to,
     foot,
     success,
+    paymentId,
     successText,
     disablePaymentId,
     goalAmount,
@@ -308,7 +310,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
     }
 
     if (opReturn !== undefined && opReturn !== '') {
-      query.push(`op_return_raw=${opReturn}`)
+      query.push(`op_return_raw=${opReturn}`);
     }
 
     url = prefixedAddress + (query.length ? `?${query.join('&')}` : '');
@@ -402,9 +404,9 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
     }
     if (opReturn !== undefined && opReturn !== '') {
       if (prefixedAddress.includes('?')) {
-        prefixedAddress += `&op_return_raw=${opReturn}`
+        prefixedAddress += `&op_return_raw=${opReturn}`;
       } else {
-        prefixedAddress += `?op_return_raw=${opReturn}`
+        prefixedAddress += `?op_return_raw=${opReturn}`;
       }
     }
     if (!copy(prefixedAddress)) return;
@@ -457,7 +459,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
   useEffect(() => {
     try {
       setOpReturn(
-        encodeOpReturnProps(props.opReturn, disablePaymentId)
+        encodeOpReturnProps(props.opReturn, paymentId, disablePaymentId),
       );
     } catch (err) {
       setErrorMsg(err.message);

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -459,7 +459,11 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
   useEffect(() => {
     try {
       setOpReturn(
-        encodeOpReturnProps(props.opReturn, paymentId, disablePaymentId),
+        encodeOpReturnProps({
+          opReturn: props.opReturn,
+          paymentId,
+          disablePaymentId: disablePaymentId === true,
+        }),
       );
     } catch (err) {
       setErrorMsg(err.message);

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -25,6 +25,7 @@ export interface WidgetContainerProps
   active?: boolean;
   amount?: number;
   opReturn?: string;
+  paymentId?: string;
   disablePaymentId?: boolean;
   currency?: currency;
   currencyObj?: currencyObject;
@@ -62,7 +63,9 @@ export interface Output {
 
 const zero = new BigNumber(0);
 const withSnackbar =
-  <T extends object>(Component: React.ComponentType<T>): React.FunctionComponent<T> =>
+  <T extends object>(
+    Component: React.ComponentType<T>,
+  ): React.FunctionComponent<T> =>
   (props): React.ReactElement =>
     (
       <SnackbarProvider>
@@ -70,13 +73,14 @@ const withSnackbar =
       </SnackbarProvider>
     );
 
-export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> = withSnackbar(
-  (props): React.ReactElement => {
+export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
+  withSnackbar((props): React.ReactElement => {
     let {
       active = true,
       to,
       opReturn,
       disablePaymentId,
+      paymentId,
       amount,
       setAmount,
       setCurrencyObj,
@@ -225,6 +229,7 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> = wi
           amount={amount}
           setAmount={setAmount}
           opReturn={opReturn}
+          paymentId={paymentId}
           disablePaymentId={disablePaymentId}
           goalAmount={goalAmount}
           currency={currency}
@@ -244,7 +249,6 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> = wi
         />
       </React.Fragment>
     );
-  },
-);
+  });
 
 export default WidgetContainer;

--- a/react/src/util/opReturn.ts
+++ b/react/src/util/opReturn.ts
@@ -108,6 +108,8 @@ export interface EncodeOpReturnParams {
   paymentId?: string;
 }
 
+// specs defined at:
+// https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/doc/standards/paybutton.md
 export function encodeOpReturnProps({
   opReturn,
   disablePaymentId,

--- a/react/src/util/opReturn.ts
+++ b/react/src/util/opReturn.ts
@@ -46,6 +46,14 @@ function stringToHex(str: string): string {
   return encodedBytes.map(byte => byte.toString(16).padStart(2, '0')).join('');
 }
 
+export function generatePaymentId(bytesAmount: number): string {
+  // Generate random bytes
+  const wordArray = lib.WordArray.random(bytesAmount);
+
+  // Convert the word array to a hex string
+  return enc.Hex.stringify(wordArray);
+}
+
 function generatePushdataPrefixedPaymentId(
   bytesAmount: number,
   disabled = false,
@@ -53,11 +61,7 @@ function generatePushdataPrefixedPaymentId(
   if (disabled) {
     return '00';
   }
-  // Generate 8 random bytes
-  const wordArray = lib.WordArray.random(bytesAmount);
-
-  // Convert the word array to a hex string
-  const hexString = enc.Hex.stringify(wordArray);
+  const hexString = generatePaymentId(bytesAmount);
 
   // The result is 18 char long:
   // ---
@@ -98,18 +102,27 @@ function getDataPushdata(data: string, disablePaymentId = false) {
 //
 // Result: 0450415900001668656c6c6f20776f726c64080102030405060708
 
-export function encodeOpReturnProps(
-  opReturn: string | undefined,
-  disablePaymentId = false,
-): string {
+export interface EncodeOpReturnParams {
+  opReturn?: string;
+  disablePaymentId: boolean;
+  paymentId?: string;
+}
+
+export function encodeOpReturnProps({
+  opReturn,
+  disablePaymentId,
+  paymentId,
+}: EncodeOpReturnParams): string {
   if (opReturn === undefined) {
     opReturn = '';
   }
 
   const dataPushdata = getDataPushdata(opReturn, disablePaymentId);
-  const pushDataPrefixedPaymentId = generatePushdataPrefixedPaymentId(
-    8,
-    disablePaymentId,
+  if (paymentId === undefined) {
+    paymentId = generatePaymentId(8);
+  }
+  const pushDataPrefixedPaymentId = prependPaymentIdWithPushdata(
+    disablePaymentId ? '' : paymentId,
   );
   return (
     OP_RETURN_PREFIX_PUSHDATA +
@@ -123,6 +136,7 @@ export function encodeOpReturnProps(
 
 export const exportedForTesting = {
   prependPaymentIdWithPushdata,
+  generatePaymentId,
   generatePushdataPrefixedPaymentId,
   stringToHex,
   getDataPushdata,


### PR DESCRIPTION
Related to #302


Depends on
---
- [x] #340 



<!-- Non-technical -->
Description
---
Adds the `paymentId` to the `PayButton` component to be passed as props to the other components; and as arguments to the `onOpen`  and `onClose` functions.

If no props arrive (as  of when creating just the Widget), the paymentId will be generated randomly in the Widget itself.


Test plan
---
Try to see the paymentId on the `onOpen` and `onClose` functions.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
