### PR TITLE
[#302] feat: payementId on success

### DIFF
--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -76,7 +76,6 @@ const withSnackbar =
 export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
   withSnackbar((props): React.ReactElement => {
     let {
-      active = true,
       to,
       opReturn,
       disablePaymentId,
@@ -158,9 +157,11 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
             snackbarOptions,
           );
 
+        const txPaymentId = transaction.opReturn?.paymentId
         if (
           cryptoAmount &&
-          receivedAmount.isEqualTo(new BigNumber(cryptoAmount))
+          receivedAmount.isEqualTo(new BigNumber(cryptoAmount)) &&
+          txPaymentId === paymentId
         ) {
           setSuccess(true);
           onSuccess?.(transaction.id, receivedAmount);
@@ -170,7 +171,6 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
         setNewTxs([]);
       },
       [
-        amount,
         onSuccess,
         onTransaction,
         enqueueSnackbar,
@@ -180,6 +180,7 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
         cryptoAmount,
         successText,
         to,
+        paymentId
       ],
     );
 
@@ -219,7 +220,7 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
       } else if (!isFiat(currency)) {
         setCryptoAmount(amount?.toString());
       }
-    }, [price, currencyObj, amount, currency, randomSatoshis]);
+    }, [price, currencyObj, amount, currency, randomSatoshis, to]);
 
     return (
       <React.Fragment>

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -39,7 +39,7 @@ export const getAddressBalance = async (
   } catch (error) {
     return;
   }
- 
+
 };
 
 export const getUTXOs = async (
@@ -172,6 +172,10 @@ export interface Transaction {
   id: string;
   hash: string;
   amount: string;
+  opReturn?: {
+    paymentId: string;
+    data: any;
+  };
   confirmed: boolean;
   timestamp: number;
   addressId: string;

--- a/react/src/util/opReturn.ts
+++ b/react/src/util/opReturn.ts
@@ -72,7 +72,7 @@ function generatePushdataPrefixedPaymentId(
   return prependPaymentIdWithPushdata(hexString);
 }
 
-function getDataPushdata(data: string, disablePaymentId = false) {
+function getDataPushdata(data: string, disablePaymentId = false): string {
   const bytesQuantity = new Blob([data]).size;
   // If paymentId is expected, limit is 8 bytes smaller
   const bytesLimit = USER_DATA_BYTES_LIMIT - (disablePaymentId ? 0 : 8);
@@ -113,7 +113,7 @@ export interface EncodeOpReturnParams {
 export function encodeOpReturnProps({
   opReturn,
   disablePaymentId,
-  paymentId,
+  paymentId
 }: EncodeOpReturnParams): string {
   if (opReturn === undefined) {
     opReturn = '';


### PR DESCRIPTION
Related to #302


Depends on
---
- [x] #353 



<!-- Non-technical -->
Description
---
Uses paymentId to fire `onSuccess`.


Test plan
---
WIP

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
