### PR TITLE
fix(357): fix documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -581,7 +581,11 @@ onTransaction = transactionCallback
 
 > **The ‘on-open’ parameter specifies the callback function that runs when the button is clicked, before the dialog opens.**
 
-?> This parameter is optional. Default value is empty. Possible values are any defined function.
+#### *callback* arguments
+
+- amount: *number* - how much money is being requested
+- paymentId: *string* - the unique identifier for the payment
+- to: *string* - where the money will be sent to
 
 **Example:**
 <!-- tabs:start -->
@@ -611,6 +615,11 @@ onOpen = successCallback
 > **The ‘on-close’ parameter specifies the callback function that runs when the dialog is closed.**
 
 ?> This parameter is optional. Default value is empty. Possible values are any defined function.
+
+#### *callback* arguments
+
+- **success**: *boolean* - status of the payment
+- **paymentId**: *string* - the paymentId
 
 **Example:**
 <!-- tabs:start -->

--- a/docs/zh-cn/README.md
+++ b/docs/zh-cn/README.md
@@ -581,6 +581,12 @@ onTransaction = transactionCallback
 
 ?> 这个参数是可选的。默认值为空。可能的值是任何已定义的函数。
 
+#### *回调* 参数
+
+- amount: *number* - 被请求的金额是多少
+- to: *string* - 资金将汇入的地方
+- paymentId: *string* - 付款的唯一标识符
+
 **Example:**
 <!-- tabs:start -->
 
@@ -609,6 +615,11 @@ onOpen = successCallback
 > **参数'on-close'指定了对话框关闭时运行的回调函数。**
 
 ?> 这个参数是可选的。默认值为空。可能的值是任何已定义的函数。
+
+#### *回调* 参数
+
+- **success**: *boolean* - 付款状态
+- **paymentId**: *string* - 付款标识
 
 **Example:**
 <!-- tabs:start -->

--- a/docs/zh-tw/README.md
+++ b/docs/zh-tw/README.md
@@ -581,6 +581,12 @@ onTransaction = transactionCallback
 
 ?> 這個參數是可選的。默認值為空。可能的值是任何已定義的函數。
 
+#### *回撥* 參數
+
+- **amount**: *number* - 被請求的金額是多少
+- **to**: *string* - 付款的唯一标识符
+- **paymentId**: *string* - 资金将汇入的地方
+
 **Example:**
 <!-- tabs:start -->
 
@@ -609,6 +615,11 @@ onOpen = successCallback
 > **參數"on-close"指定了對話框關閉時運行的回呼函數。**
 
 ?> 這個參數是可選的。默認值為空。可能的值是任何已定義的函數。
+
+#### *回撥* 參數
+
+- **success**: *boolean* - 付款狀態
+- **paymentId**: *string* - 付款標識
 
 **Example:**
 <!-- tabs:start -->


### PR DESCRIPTION
Related to #357

<!-- Non-technical -->
Description
---
- added parameters to the documentation


Test plan
---
run `yarn start:docs` and check if the documentation on `onOpen` and `onClose` has the paremeters

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 

Remarks
---
-->
