### PR TITLE
fix:disable payment id

### DIFF
--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -462,7 +462,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
         encodeOpReturnProps({
           opReturn: props.opReturn,
           paymentId,
-          disablePaymentId: disablePaymentId === true,
+          disablePaymentId: disablePaymentId ?? false,
         }),
       );
     } catch (err) {


### PR DESCRIPTION
Related to #367 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
fix disable_payment_id prop not working


Test plan
---
open the project, run `yarn build` and test the button passing disablePaymentId true like this: 
`disable-payment-id="true"`

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
