### PR TITLE
fix(#369): call on-succes

### DIFF
--- a/react/src/components/PaymentDialog/PaymentDialog.tsx
+++ b/react/src/components/PaymentDialog/PaymentDialog.tsx
@@ -73,10 +73,6 @@ export const PaymentDialog = (
     if (onClose) onClose(success, paymentId);
     setSuccess(false);
   };
-  const handleSuccess = (txid: string, amount: BigNumber): void => {
-    setSuccess(true);
-    onSuccess?.(txid, amount);
-  };
 
   useEffect(() => {
     const invalidAmount = amount !== undefined && isNaN(+amount);
@@ -126,7 +122,7 @@ export const PaymentDialog = (
           animation={animation}
           randomSatoshis={randomSatoshis}
           hideToasts={hideToasts}
-          onSuccess={handleSuccess}
+          onSuccess={onSuccess}
           onTransaction={onTransaction}
           successText={successText}
           disabled={disabled}

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -161,7 +161,7 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
         if (
           cryptoAmount &&
           receivedAmount.isEqualTo(new BigNumber(cryptoAmount)) &&
-          txPaymentId === paymentId
+          (paymentId ? txPaymentId === paymentId : true)
         ) {
           setSuccess(true);
           onSuccess?.(transaction.id, receivedAmount);


### PR DESCRIPTION
Related to #369 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
fix call on-succes conditions
 fixed amount not being set correctly after changign

Test plan
---

Open the project run `yarn build` , do a transaction with the amount indicated by the button and it should trigger the onSuccess function you set

Test 1: 
 set a button passing the `on-success` function > do the payment > check if the onSuccess function was triggered

Test 2: 
 set a widget passing the `on-success` function >  do the payment >  check if the onSuccess function was triggered 
 
 Test 3
  set a widget passing the `on-success` function   and set an `amount` > change the amount manually> proceed with the payment >   check if the onSuccess function was triggered 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
--- 
-->
