### PR TITLE
feat: add start rollup command

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:react:clean": "yarn clean:react && yarn build:react",
     "clean:paybutton": "rm -rf paybutton/node_modules paybutton/dist",
     "clean:app": "yarn clean:react && yarn clean:paybutton",
-    "clean:build": "yarn clean:app && yarn build"
+    "clean:build": "yarn clean:app && yarn build",
+    "start:rollup": "cd paybutton && yarn && yarn dev"
   }
 }


### PR DESCRIPTION
Related to #380 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Added the command `start:rollup` to the root of the monorepo


Test plan
---
Open the project, run `start:rollup`

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
