### PR TITLE
[S#811] use simplified tx

### DIFF
--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -144,10 +144,9 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
       (transaction: Transaction) => {
         if (sound && !hideToasts) txSound.play().catch(() => {});
 
-        const { 
-          amount: transactionAmount, 
-          opReturn, 
-          hash, 
+        const {
+          amount: transactionAmount,
+          opReturn,
           paymentId: transactionPaymentId } = transaction;
         const receivedAmount = new BigNumber(transactionAmount);
 
@@ -162,18 +161,13 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
         const txPaymentId = transactionPaymentId ?? opReturn?.paymentId
         const isCryptoAmountValid = (cryptoAmount && receivedAmount.isEqualTo(new BigNumber(cryptoAmount))) || !cryptoAmount;
         const isPaymentIdValid = paymentId ? txPaymentId === paymentId : true;
-        const transactionResponse: Transaction = {
-          hash: hash,
-          amount: transactionAmount,
-          paymentId: txPaymentId
-        };
 
-        if (isCryptoAmountValid && isPaymentIdValid) 
+        if (isCryptoAmountValid && isPaymentIdValid)
         {
           setSuccess(true);
-          onSuccess?.(transactionResponse);
+          onSuccess?.(transaction);
         } else {
-          onTransaction?.(transactionResponse);
+          onTransaction?.(transaction);
         }
         setNewTxs([]);
       },

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -146,7 +146,6 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
 
         const {
           amount: transactionAmount,
-          opReturn,
           paymentId: transactionPaymentId } = transaction;
         const receivedAmount = new BigNumber(transactionAmount);
 
@@ -158,7 +157,7 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
             }Received ${receivedAmount} ${currencyTicker}`,
             snackbarOptions,
           );
-        const txPaymentId = transactionPaymentId ?? opReturn?.paymentId
+        const txPaymentId = transactionPaymentId
         const isCryptoAmountValid = (cryptoAmount && receivedAmount.isEqualTo(new BigNumber(cryptoAmount))) || !cryptoAmount;
         const isPaymentIdValid = paymentId ? txPaymentId === paymentId : true;
 

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -151,15 +151,15 @@ export const getCashtabProviderStatus = () => {
   return false;
 };
 
+
 export interface Transaction {
-  hash: string;
-  amount: string;
-  paymentId?: string;
-  confirmed?: boolean;
-  opReturn?: {
-    paymentId: string;
-    data: any;
-  };
+  hash: string
+  amount: string
+  paymentId?: string
+  confirmed?: boolean
+  message: string
+  timestamp: number
+  address: string
 }
 
 export interface UtxoDetails {

--- a/react/src/util/api-client.ts
+++ b/react/src/util/api-client.ts
@@ -155,7 +155,7 @@ export const getCashtabProviderStatus = () => {
 export interface Transaction {
   hash: string
   amount: string
-  paymentId?: string
+  paymentId: string
   confirmed?: boolean
   message: string
   timestamp: number


### PR DESCRIPTION
Related to https://github.com/PayButton/paybutton-server/issues/811

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Removes redundant `opReturn`, makes `paymentId` mandatory (if not present, it will be empty) and sends it all to `onSuccess` and `onTransaction`.


Test plan
---
Should be tested with https://github.com/PayButton/paybutton-server/pull/821
Make sure to use
```
{                                      
  "wsBaseUrl": "http://localhost:5000",
  "apiBaseUrl": "http://localhost:3000"
}                                      
```
... in react/src/paybutton-config.json before building. Then run the server locally, and use the builded .js wherever you prefer to test if  receiveing a tx executes onSuccess /onTransaction without erroring.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
