### PR TITLE
fix: cashtab url with op_return_raw parameter

### DIFF
--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -354,17 +354,11 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
   const handleButtonClick = () => {
     if (addressType === 'XEC') {
       const hasExtension = getCashtabProviderStatus();
-      let thisAmount: number | undefined;
-      if (convertedCurrencyObj) {
-        thisAmount = convertedCurrencyObj.float;
-      } else {
-        thisAmount = thisCurrencyObject ? thisCurrencyObject.float : undefined;
-      }
       if (!hasExtension) {
         window.location.href = url;
         const isMobile = window.matchMedia('(pointer:coarse)').matches;
         if (isMobile) {
-          window.location.href = `https://cashtab.com/#/send?address=${to}&value=${thisAmount}&op_return_raw=${opReturn}`;
+          window.location.href = `https://cashtab.com/#/send?bip21=${url}`;
         } else {
           window.location.href = url;
         }
@@ -374,9 +368,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
             type: 'FROM_PAGE',
             text: 'Cashtab',
             txInfo: {
-              address: to,
-              value: thisAmount ?? null,
-              op_return_raw: opReturn ?? null
+              bip21: url
             },
           },
           '*',

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -364,7 +364,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
         window.location.href = url;
         const isMobile = window.matchMedia('(pointer:coarse)').matches;
         if (isMobile) {
-          window.location.href = `https://cashtab.com/#/send?address=${to}&value=${thisAmount}`;
+          window.location.href = `https://cashtab.com/#/send?address=${to}&value=${thisAmount}&op_return_raw=${opReturn}`;
         } else {
           window.location.href = url;
         }
@@ -376,6 +376,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
             txInfo: {
               address: to,
               value: thisAmount ?? null,
+              op_return_raw: opReturn ?? null
             },
           },
           '*',


### PR DESCRIPTION
<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Opening cashtab by clicking the "Send with XYZ Wallet" button should now include the op_return data.


Test plan
---
There are three states to test:
1. PC, with cashtab extension
2. PC, without the extension
3. Mobile

When clicking on the pay button of the PayButton, regardless if the amount is in XEC or in fiat, **1.** and **3.** should open cashtab with the right address, amount and with the OP_RETURN set. **2.** will input BIP21 directly into the browser URL bar. It will then depend on your computer being configured  to have a default program that opens `ecash:` protocol URIs.

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
