### PR TITLE
[#391] feat: on open uses crypto amount

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -597,7 +597,7 @@ onTransaction = transactionCallback
 
 #### *callback* arguments
 
-- amount: *number* - how much money is being requested
+- amount: *number* - how much money is being requested (in crypto)
 - paymentId: *string* - the unique identifier for the payment
 - to: *string* - where the money will be sent to
 

--- a/docs/zh-cn/README.md
+++ b/docs/zh-cn/README.md
@@ -595,7 +595,7 @@ onTransaction = transactionCallback
 
 #### *回调* 参数
 
-- amount: *number* - 被请求的金额是多少
+amount: number - 请求的金额是多少（以加密货币计)
 - to: *string* - 资金将汇入的地方
 - paymentId: *string* - 付款的唯一标识符
 

--- a/docs/zh-cn/README.md
+++ b/docs/zh-cn/README.md
@@ -595,7 +595,7 @@ onTransaction = transactionCallback
 
 #### *回调* 参数
 
-amount: number - 请求的金额是多少（以加密货币计)
+- amount: number - 请求的金额是多少（以加密货币计)
 - to: *string* - 资金将汇入的地方
 - paymentId: *string* - 付款的唯一标识符
 

--- a/docs/zh-tw/README.md
+++ b/docs/zh-tw/README.md
@@ -594,7 +594,7 @@ onTransaction = transactionCallback
 
 #### *回撥* 參數
 
-amount: number - 請求的金額是多少（以加密貨幣計)
+- amount: number - 請求的金額是多少（以加密貨幣計)
 - **to**: *string* - 付款的唯一标识符
 - **paymentId**: *string* - 资金将汇入的地方
 

--- a/docs/zh-tw/README.md
+++ b/docs/zh-tw/README.md
@@ -594,7 +594,7 @@ onTransaction = transactionCallback
 
 #### *回撥* 參數
 
-- **amount**: *number* - 被請求的金額是多少
+amount: number - 請求的金額是多少（以加密貨幣計)
 - **to**: *string* - 付款的唯一标识符
 - **paymentId**: *string* - 资金将汇入的地方
 

--- a/react/src/components/PayButton/PayButton.tsx
+++ b/react/src/components/PayButton/PayButton.tsx
@@ -93,9 +93,13 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
     callback()
   }
   const handleButtonClick = useCallback(async (): Promise<void> => {
-    if (isFiat(currency)) void waitPrice(() => {
-      if (onOpen !== undefined) onOpen(cryptoAmountRef.current, to, paymentId);
-    })
+    if (onOpen !== undefined) {
+      if (isFiat(currency)) {
+        void waitPrice(() => { onOpen(cryptoAmountRef.current, to, paymentId) })
+      } else {
+        onOpen(amount, to, paymentId)
+      }
+    }
     setDialogOpen(true);
   }, [cryptoAmount, to, paymentId, price])
 

--- a/react/src/components/PayButton/PayButton.tsx
+++ b/react/src/components/PayButton/PayButton.tsx
@@ -43,6 +43,7 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
   const [amount, setAmount] = useState(props.amount);
  
   const [currencyObj, setCurrencyObj] = useState<currencyObject | undefined>();
+  const [cryptoAmount, setCryptoAmount] = useState<string>();
 
   const {
     to,
@@ -69,7 +70,7 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
   const [paymentId] = useState(!disablePaymentId ? generatePaymentId(8) : undefined);
 
   const handleButtonClick = (): void => {
-    if (onOpen !== undefined) onOpen(amount, to, paymentId);
+    if (onOpen !== undefined) onOpen(cryptoAmount, to, paymentId);
     setDialogOpen(true);
   };
   const handleCloseDialog = (success?: boolean, paymentId?: string): void => {
@@ -147,6 +148,8 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
         setAmount={setAmount}
         currencyObj={currencyObj}
         setCurrencyObj={setCurrencyObj}
+        cryptoAmount={cryptoAmount}
+        setCryptoAmount={setCryptoAmount}
         currency={currency}
         animation={animation}
         randomSatoshis={randomSatoshis}

--- a/react/src/components/PayButton/PayButton.tsx
+++ b/react/src/components/PayButton/PayButton.tsx
@@ -72,7 +72,6 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
   } = Object.assign({}, PayButton.defaultProps, props);
 
   const [paymentId] = useState(!disablePaymentId ? generatePaymentId(8) : undefined);
-  const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
   useEffect(() => {
     priceRef.current = price;
@@ -82,16 +81,14 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
     cryptoAmountRef.current = cryptoAmount;
   }, [cryptoAmount]);
 
-  const waitPrice = async (callback: Function) => {
-    while (true) {
+  const waitPrice = (callback: Function) => {
+    const intervalId = setInterval(() => {
       if (priceRef.current !== 0) {
-        break;
-      } else {
-        await delay(300);
+        clearInterval(intervalId);
+        callback();
       }
-    }
-    callback()
-  }
+    }, 300);
+  };
   const handleButtonClick = useCallback(async (): Promise<void> => {
     if (onOpen !== undefined) {
       if (isFiat(currency)) {

--- a/react/src/components/PayButton/PayButton.tsx
+++ b/react/src/components/PayButton/PayButton.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 
 import { Theme, ThemeName, ThemeProvider, useTheme } from '../../themes';
 import Button, { ButtonProps } from '../Button/Button';
-import { Transaction, currency, isFiat, getBchFiatPrice, getXecFiatPrice } from '../../util/api-client';
+import { Transaction, currency, isFiat, getFiatPrice } from '../../util/api-client';
 import { PaymentDialog } from '../PaymentDialog/PaymentDialog';
 import { getCurrencyTypeFromAddress, isValidCashAddress, isValidXecAddress } from '../../util/address';
 import { currencyObject, getCurrencyObject } from '../../util/satoshis';
@@ -125,29 +125,19 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
     }
   }, [dialogOpen, props.amount, currency, randomSatoshis]);
 
-  const getPrice = useCallback(async (): Promise<void> => {
-    try {
-      if (isFiat(currency) && isValidCashAddress(to)) {
-        const data = await getBchFiatPrice(currency, apiBaseUrl);
-
-        const { price } = data;
-        setPrice(price);
-      } else if (isFiat(currency) && isValidXecAddress(to)) {
-        const data = await getXecFiatPrice(currency, apiBaseUrl);
-
-        const { price } = data;
-        setPrice(price);
-      }
-    } catch (error) {
-      console.log('err', error);
+  const getPrice = useCallback(
+    async () => {
+      const price = await getFiatPrice(currency, to, apiBaseUrl)
+      if (price !== null) setPrice(price)
     }
-  }, [currency, to, apiBaseUrl]);
+    , [currency, to, apiBaseUrl]
+  );
 
   useEffect(() => {
     if (isFiat(currency) && price === 0) {
       getPrice();
     }
-  }, [currency, getPrice, price]);
+  }, [currency, getPrice, to, price]);
 
   useEffect(() => {
     console.log('other eff gets', price)

--- a/react/src/components/PayButton/PayButton.tsx
+++ b/react/src/components/PayButton/PayButton.tsx
@@ -140,7 +140,6 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
   }, [currency, getPrice, to, price]);
 
   useEffect(() => {
-    console.log('other eff gets', price)
     if (currencyObj && isFiat(currency) && price) {
       const addressType: currency = getCurrencyTypeFromAddress(to);
       const convertedObj = getCurrencyObject(

--- a/react/src/components/PaymentDialog/PaymentDialog.tsx
+++ b/react/src/components/PaymentDialog/PaymentDialog.tsx
@@ -18,6 +18,7 @@ export interface PaymentDialogProps extends ButtonProps {
   currency?: currency;
   currencyObj?: currencyObject;
   cryptoAmount?: string;
+  price?: number;
   setCryptoAmount: Function;
   setCurrencyObj: Function;
   theme?: ThemeName | Theme;
@@ -55,6 +56,7 @@ export const PaymentDialog = (
     currencyObj,
     setCurrencyObj,
     cryptoAmount,
+    price,
     setCryptoAmount,
     successText,
     animation,
@@ -125,6 +127,7 @@ export const PaymentDialog = (
           currencyObj={currencyObj}
           setCurrencyObj={setCurrencyObj}
           cryptoAmount={cryptoAmount}
+          price={price}
           setCryptoAmount={setCryptoAmount}
           currency={currency}
           animation={animation}

--- a/react/src/components/PaymentDialog/PaymentDialog.tsx
+++ b/react/src/components/PaymentDialog/PaymentDialog.tsx
@@ -19,7 +19,6 @@ export interface PaymentDialogProps extends ButtonProps {
   currencyObj?: currencyObject;
   cryptoAmount?: string;
   price?: number;
-  setCryptoAmount: Function;
   setCurrencyObj: Function;
   theme?: ThemeName | Theme;
   successText?: string;
@@ -57,7 +56,6 @@ export const PaymentDialog = (
     setCurrencyObj,
     cryptoAmount,
     price,
-    setCryptoAmount,
     successText,
     animation,
     randomSatoshis,
@@ -128,7 +126,6 @@ export const PaymentDialog = (
           setCurrencyObj={setCurrencyObj}
           cryptoAmount={cryptoAmount}
           price={price}
-          setCryptoAmount={setCryptoAmount}
           currency={currency}
           animation={animation}
           randomSatoshis={randomSatoshis}

--- a/react/src/components/PaymentDialog/PaymentDialog.tsx
+++ b/react/src/components/PaymentDialog/PaymentDialog.tsx
@@ -17,6 +17,8 @@ export interface PaymentDialogProps extends ButtonProps {
   disablePaymentId?: boolean;
   currency?: currency;
   currencyObj?: currencyObject;
+  cryptoAmount?: string;
+  setCryptoAmount: Function;
   setCurrencyObj: Function;
   theme?: ThemeName | Theme;
   successText?: string;
@@ -52,6 +54,8 @@ export const PaymentDialog = (
     currency,
     currencyObj,
     setCurrencyObj,
+    cryptoAmount,
+    setCryptoAmount,
     successText,
     animation,
     randomSatoshis,
@@ -120,6 +124,8 @@ export const PaymentDialog = (
           setAmount={setAmount}
           currencyObj={currencyObj}
           setCurrencyObj={setCurrencyObj}
+          cryptoAmount={cryptoAmount}
+          setCryptoAmount={setCryptoAmount}
           currency={currency}
           animation={animation}
           randomSatoshis={randomSatoshis}

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -176,6 +176,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
   const classes = useStyles({ success, loading, theme });
 
   const [thisAmount, setThisAmount] = useState(props.amount);
+  const [hasPrice, setHasPrice] = useState(props.price !== undefined && props.price > 0);
   const [thisCurrencyObject, setThisCurrencyObject] = useState(
     props.currencyObject,
   );
@@ -210,7 +211,9 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
   }, [recentlyCopied]);
 
   const query: string[] = [];
-  const hasPrice: boolean = price !== undefined && price > 0;
+  useEffect(() => {
+    setHasPrice(price !== undefined && price > 0)
+  }, [price])
   let prefixedAddress: string;
 
   useEffect(() => {
@@ -349,7 +352,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
         setUrl(url);
       }
     }
-  }, [to, thisCurrencyObject, price, thisAmount, opReturn]);
+  }, [to, thisCurrencyObject, price, thisAmount, opReturn, hasPrice]);
 
   const handleButtonClick = () => {
     if (addressType === 'XEC') {
@@ -504,7 +507,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
         setErrorMsg('Goal Value must be a number');
       }
     }
-  }, [totalReceived, currency, goalAmount, price]);
+  }, [totalReceived, currency, goalAmount, price, hasPrice]);
 
   return (
     <ThemeProvider value={theme}>

--- a/react/src/components/Widget/Widget.tsx
+++ b/react/src/components/Widget/Widget.tsx
@@ -216,7 +216,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
   useEffect(() => {
     (async (): Promise<void> => {
       // subscribes address on paybutton server
-      await getAddressDetails(to, apiBaseUrl);
+      void getAddressDetails(to, apiBaseUrl);
       const newSocket = io(`${wsBaseUrl ?? config.wsBaseUrl}/addresses`, {
         query: { addresses: [to] },
       });

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -30,6 +30,8 @@ export interface WidgetContainerProps
   disablePaymentId?: boolean;
   currency?: currency;
   currencyObj?: currencyObject;
+  cryptoAmount?: string;
+  setCryptoAmount: Function;
   setCurrencyObj: Function;
   randomSatoshis?: boolean | number;
   hideToasts?: boolean;
@@ -86,6 +88,8 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
       setCurrencyObj,
       currencyObj,
       currency = '' as currency,
+      cryptoAmount,
+      setCryptoAmount,
       animation,
       randomSatoshis = false,
       hideToasts = false,
@@ -114,7 +118,6 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
     }, [paymentId, disablePaymentId]);
     const [success, setSuccess] = useState(false);
     const { enqueueSnackbar } = useSnackbar();
-    const [cryptoAmount, setCryptoAmount] = useState<string>();
 
     const [price, setPrice] = useState(0);
 

--- a/react/src/components/Widget/WidgetContainer.tsx
+++ b/react/src/components/Widget/WidgetContainer.tsx
@@ -29,7 +29,6 @@ export interface WidgetContainerProps
   currencyObj?: currencyObject;
   cryptoAmount?: string;
   price?: number;
-  setCryptoAmount: Function;
   setCurrencyObj: Function;
   randomSatoshis?: boolean | number;
   hideToasts?: boolean;
@@ -88,7 +87,6 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
       currency = '' as currency,
       cryptoAmount,
       price,
-      setCryptoAmount,
       animation,
       randomSatoshis = false,
       hideToasts = false,


### PR DESCRIPTION
Related to #391

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
In order to have `onOpen` use the crypto amount, we have to know the crypto price before opening the button. This is now the case, as we fetch the price just as the component loads.



Test plan
---

- Make sure onOpen works with the crypto amount even if the paybutton is fiat,
- Make sure fiat widgets still work normally; i.e they fetch the price too.


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
