### PR TITLE
fix: hover payment dialog

### DIFF
--- a/react/lib/components/PayButton/PayButton.tsx
+++ b/react/lib/components/PayButton/PayButton.tsx
@@ -221,6 +221,7 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
         onClose={handleCloseDialog}
         wsBaseUrl={wsBaseUrl}
         apiBaseUrl={apiBaseUrl}
+        hoverText={hoverText}
       />
       {errorMsg && (
         <p

--- a/react/lib/components/PaymentDialog/PaymentDialog.tsx
+++ b/react/lib/components/PaymentDialog/PaymentDialog.tsx
@@ -19,6 +19,7 @@ export interface PaymentDialogProps extends ButtonProps {
   currencyObj?: currencyObject;
   cryptoAmount?: string;
   price?: number;
+  hoverText?: string;
   setCurrencyObj: Function;
   theme?: ThemeName | Theme;
   successText?: string;
@@ -70,6 +71,7 @@ export const PaymentDialog = (
     container,
     wsBaseUrl,
     apiBaseUrl,
+    hoverText
   } = Object.assign({}, PaymentDialog.defaultProps, props);
 
   const handleWidgetClose = (): void => {
@@ -138,6 +140,7 @@ export const PaymentDialog = (
           goalAmount={goalAmount}
           wsBaseUrl={wsBaseUrl}
           apiBaseUrl={apiBaseUrl}
+          hoverText={hoverText}
           foot={
             success && (
               <ButtonComponent

--- a/react/lib/components/Widget/WidgetContainer.tsx
+++ b/react/lib/components/Widget/WidgetContainer.tsx
@@ -99,6 +99,7 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
       wsBaseUrl,
       apiBaseUrl,
       successText,
+      hoverText,
       ...widgetProps
     } = props;
 
@@ -240,6 +241,7 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
           wsBaseUrl={wsBaseUrl}
           apiBaseUrl={apiBaseUrl}
           successText={successText}
+          hoverText={hoverText}
         />
       </React.Fragment>
     );


### PR DESCRIPTION
Related to #336 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fixed hover not working on payment dialog 


Test plan
---
Run `yarn build `  and `yarn dev`
in the dev demo page in` localhost:1001` check the option that has a hover-text set and make sure the hover set is working on the payment dialog. 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
