### PR TITLE
chore: add docsify resolution

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -11,5 +11,8 @@
     "serve": "npx docsify serve --port 3001"
   },
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "resolutions": {
+    "docsify": "^4.13.1"
+  }
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -64,9 +64,9 @@ anymatch@~3.1.2:
     picomatch "^2.0.4"
 
 binary-extensions@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
-  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
+  integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
 
 boxen@^4.2.0:
   version "4.2.0"
@@ -136,9 +136,9 @@ chalk@^3.0.0:
     supports-color "^7.1.0"
 
 chokidar@^3.5.0:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
-  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
   dependencies:
     anymatch "~3.1.2"
     braces "~3.0.2"
@@ -326,7 +326,7 @@ docsify-server-renderer@>=4.10.0:
     node-fetch "^2.6.6"
     resolve-pathname "^3.0.0"
 
-docsify@^4.12.2, docsify@^4.12.4:
+docsify@^4.12.2, docsify@^4.12.4, docsify@^4.13.1:
   version "4.13.1"
   resolved "https://registry.yarnpkg.com/docsify/-/docsify-4.13.1.tgz#5ad89d3c0529d336bd1d1c20a664db129afd607a"
   integrity sha512-BsDypTBhw0mfslw9kZgAspCMZSM+sUIIDg5K/t1hNLkvbem9h64ZQc71e1IpY+iWsi/KdeqfazDfg52y2Lmm0A==
@@ -728,9 +728,9 @@ marked@^1.2.9:
   integrity sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==
 
 marked@^11.1.1:
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-11.1.1.tgz#e1b2407241f744fb1935fac224680874d9aff7a3"
-  integrity sha512-EgxRjgK9axsQuUa/oKMx5DEY8oXpKJfk61rT5iY3aRlgU6QJtUcxU5OAymdhCvWvhYcd9FKmO5eQoX8m9VGJXg==
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-11.2.0.tgz#fc908aeca962b721b0392ee4205e6f90ebffb074"
+  integrity sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw==
 
 medium-zoom@^1.0.6:
   version "1.1.0"


### PR DESCRIPTION
Related to #261 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---

Added resolutions with docsify pointing to the latest version of it

Test plan
---
Run `yarn start:docs` go to `docs/node_modules/docsify/package.json` and make sure the version is  field is set to `"4.13.1"`

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
