### PR TITLE
Chore/add tests coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 .env.local
 paybutton/dev/demo/paybutton.js
+react/coverage

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "cd paybutton && yarn dev",
     "test": "cd react && yarn test",
+    "test:coverage": "cd react && yarn test:coverage",
     "build:react": "cd react && yarn && yarn build",
     "build:paybutton": "cd paybutton && yarn && yarn build",
     "start:paybutton": "cd paybutton && yarn && yarn start",

--- a/react/jest.config.js
+++ b/react/jest.config.js
@@ -20,4 +20,7 @@ module.exports = {
   transformIgnorePatterns: [
     'node_modules/(?!(@babylonjs/core|@babylonjs/loaders)).+.[t|j]sx?$',
   ],
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>"
+  }
 };

--- a/react/jest.config.js
+++ b/react/jest.config.js
@@ -3,4 +3,21 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   modulePaths: ['./'],
+  collectCoverageFrom: [
+    'lib/**/*.{ts,tsx,mjs}',
+  ],
+  coveragePathIgnorePatterns: [
+    "src/*",
+    "lib/themes",
+    "lib/tests",
+    "lib/assets"
+  ],
+  coverageThreshold: {
+    "global": {
+      "lines": 80
+    }
+  },
+  transformIgnorePatterns: [
+    'node_modules/(?!(@babylonjs/core|@babylonjs/loaders)).+.[t|j]sx?$',
+  ],
 };

--- a/react/package.json
+++ b/react/package.json
@@ -24,7 +24,8 @@
     "dev": "concurrently yarn:watch yarn:storybook",
     "storybook": "start-storybook -p 6006",
     "watch": "microbundle watch --jsx React.createElement --no-compress --format modern,cjs",
-    "test": "jest"
+    "test": "jest",
+    "test:coverage": "jest --coverage"
   },
   "peerDependencies": {
     "react": "17.0.0",


### PR DESCRIPTION
Related to #405 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Set up tests coverage command


Test plan
---
`yarn build && yarn dev` 
to test coverage run: 
`yarn jest:coverage`
and check folder `react/coverage`
<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
