### PR TITLE
Chore/add socket util

### DIFF
--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -26,9 +26,10 @@ import BarChart from '../BarChart/BarChart';
 import PencilIcon from '../../assets/edit-pencil';
 import io, { Socket } from 'socket.io-client';
 import { encodeOpReturnProps } from '../../util/opReturn';
-import { getAddressDetails, setListener, getAddressBalance, isFiat, getCashtabProviderStatus } from '../../util/api-client';
+import { getAddressDetails, getAddressBalance, isFiat, getCashtabProviderStatus } from '../../util/api-client';
 import { getCurrencyObject } from '../../util/satoshis';
 import { Currency, CurrencyObject, Transaction, CryptoCurrency } from '../../util/types';
+import { setListener } from '../../util/socket';
 
 type QRCodeProps = BaseQRCodeProps & { renderAs: 'svg' };
 

--- a/react/lib/util/api-client.ts
+++ b/react/lib/util/api-client.ts
@@ -10,10 +10,8 @@ import {
   Currency,
   CryptoCurrency,
   FiatCurrency,
-  BroadcastTxData
 } from './types';
 import { FIAT_CURRENCIES, CRYPTO_CURRENCIES } from './constants';
-import { Socket } from 'socket.io-client';
 
 export const getAddressDetails = async (
   address: string,
@@ -22,14 +20,6 @@ export const getAddressDetails = async (
   const res = await fetch(`${rootUrl}/address/transactions/${address}`);
   return res.json();
 };
-export const setListener = (socket: Socket, setNewTxs: Function): void => {
-  socket.on('incoming-txs', (broadcastedTxData: BroadcastTxData) => {
-    const unconfirmedTxs = broadcastedTxData.txs.filter(tx => tx.confirmed === false)
-    if (broadcastedTxData.messageType === 'NewTx' && unconfirmedTxs.length !== 0) {
-      setNewTxs(unconfirmedTxs)
-    }
-  })
-}
 
 export const getAddressBalance = async (
   address: string,

--- a/react/lib/util/socket.ts
+++ b/react/lib/util/socket.ts
@@ -1,0 +1,17 @@
+import { Socket } from 'socket.io-client';
+
+import { BroadcastTxData } from './types';
+
+export const setListener = (socket: Socket, setNewTxs: Function): void => {
+  socket.on('incoming-txs', (broadcastedTxData: BroadcastTxData) => {
+    const unconfirmedTxs = broadcastedTxData.txs.filter(
+      tx => tx.confirmed === false,
+    );
+    if (
+      broadcastedTxData.messageType === 'NewTx' &&
+      unconfirmedTxs.length !== 0
+    ) {
+      setNewTxs(unconfirmedTxs);
+    }
+  });
+};


### PR DESCRIPTION
Related to #405 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Moved socket logic from the API client to a new utility file called `socket.ts`. 
The reason for moving this function is to isolate Its logic. The logic of `setListener` is outside the scope of the API client's responsibilities. In terms of testing, when we write tests for the API client, we would have to check both the API logic (such as Axios calls and error handling) and the socket logic (such as if it correctly creates the socket listener and handles incoming transactions) This would result in a larger test file with tests of different scopes.



Test plan
---
`yarn build && yarn dev `
also check
`yarn test`

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
