### PR TITLE
docs: rename can edit

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -11,7 +11,7 @@
   - [text](/?id=text)
   - [hover-text](/?id=hover-text)
   - [goal-amount](/?id=goal-amount)
-  - [can-edit](/?id=can-edit)
+  - [editable](/?id=editable)
   - [theme](/?id=theme)
   - [animation](/?id=animation)
   - [success-text](/?id=success-text)

--- a/docs/zh-cn/_sidebar.md
+++ b/docs/zh-cn/_sidebar.md
@@ -10,7 +10,7 @@
   - [text](/zh-cn/?id=text)
   - [hover-text](/zh-cn/?id=hover-text)
   - [goal-amount](/zh-cn/?id=goal-amount)
-  - [can-edit](/zh-cn/?id=can-edit)
+  - [editable](/zh-cn/?id=editable)
   - [theme](/zh-cn/?id=theme)
   - [animation](/zh-cn/?id=animation)
   - [success-text](/zh-cn/?id=success-text)

--- a/docs/zh-tw/_sidebar.md
+++ b/docs/zh-tw/_sidebar.md
@@ -10,7 +10,7 @@
   - [text](/zh-tw/?id=text)
   - [hover-text](/zh-tw/?id=hover-text)
   - [goal-amount](/zh-tw/?id=goal-amount)
-  - [can-edit](/zh-tw/?id=can-edit)
+  - [editable](/zh-tw/?id=editable)
   - [theme](/zh-tw/?id=theme)
   - [animation](/zh-tw/?id=animation)
   - [success-text](/zh-tw/?id=success-text)


### PR DESCRIPTION
Related to #403 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
- Just renamed can-edit prop, currently it is called editable


Test plan
---
`yarn start:docs`

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
