### PR TITLE
feat: sideshift integration

### DIFF
--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -687,7 +687,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
               />
 
               <Typography>
-                <a onClick={() => {setUseSideshift(false)}}>Trade with xec</a>
+                <a onClick={() => {setUseSideshift(false)}}>Trade with {addressType}</a>
               </Typography>
             </>
               // END: Sideshift region
@@ -775,7 +775,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
             )}
           <Box py={1}>
             <Typography>
-              <a onClick={() => {setUseSideshift(true)}}>Don't have any XEC?</a>
+              <a onClick={() => {setUseSideshift(true)}}>Don't have any {addressType}?</a>
             </Typography>
           </Box>
           </>

--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -215,7 +215,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
   useEffect(() => {
     (async () => {
     if (useSideshift === true) {
-      const coins = await getCoins()
+      const coins = await getCoins(addressType)
       setCoins(coins)
     }
     })()

--- a/react/lib/util/sideshift.ts
+++ b/react/lib/util/sideshift.ts
@@ -1,24 +1,49 @@
+const BASE_SIDESHIFT_URL='https://sideshift.ai/api/v2/'
+
 interface TokenDetails {
-    network: {
-        contractAddress: string;
-    };
+  [network: string]: {
+    contractAddress: string;
     decimals: number;
-    depositOffline?: string[] | boolean;
-    settleOffline?: string[] | boolean;
+  }
 }
 
-interface Coin {
+export interface Coin {
     networks: string[];
     coin: string;
     name: string;
     hasMemo: boolean;
     fixedOnly: string[] | boolean;
     variableOnly: string[] | boolean;
-    tokenDetails: TokenDetails[];
+    tokenDetails: TokenDetails;
+    depositOffline?: string[] | boolean;
+    settleOffline?: string[] | boolean;
 }
 
 export async function getCoins(): Promise<Coin[]> {
-  const res = await fetch('https://sideshift.ai/api/v2/coins')
+  const res = await fetch(BASE_SIDESHIFT_URL + 'coins')
   const data = await res.json()
-  return data as Coin[]
+
+  const coins = data as Coin[]
+  coins.sort((a, b) => a.name < b.name ? -1 : 1)
+  return coins
+}
+
+export interface Pair {
+  min: string;
+  max: string;
+  rate: string;
+  depositCoin: string;
+  settleCoin: string;
+  depositNetwork: string;
+  settleNetwork: string;
+}
+
+async function getPair(from: string, to: string): Promise<Pair> {
+  const res = await fetch(BASE_SIDESHIFT_URL + `pair/${from}/${to}`)
+  const data = await res.json()
+  return data as Pair
+}
+
+export async function getXecPair(from: string): Promise<Pair> {
+  return getPair(from, 'ecash-xec')
 }

--- a/react/lib/util/sideshift.ts
+++ b/react/lib/util/sideshift.ts
@@ -1,0 +1,24 @@
+interface TokenDetails {
+    network: {
+        contractAddress: string;
+    };
+    decimals: number;
+    depositOffline?: string[] | boolean;
+    settleOffline?: string[] | boolean;
+}
+
+interface Coin {
+    networks: string[];
+    coin: string;
+    name: string;
+    hasMemo: boolean;
+    fixedOnly: string[] | boolean;
+    variableOnly: string[] | boolean;
+    tokenDetails: TokenDetails[];
+}
+
+export async function getCoins(): Promise<Coin[]> {
+  const res = await fetch('https://sideshift.ai/api/v2/coins')
+  const data = await res.json()
+  return data as Coin[]
+}

--- a/react/lib/util/sideshift.ts
+++ b/react/lib/util/sideshift.ts
@@ -19,13 +19,13 @@ export interface Coin {
     settleOffline?: string[] | boolean;
 }
 
-export async function getCoins(): Promise<Coin[]> {
+export async function getCoins(originCoin: string): Promise<Coin[]> {
   const res = await fetch(BASE_SIDESHIFT_URL + 'coins')
   const data = await res.json()
 
   const coins = data as Coin[]
   coins.sort((a, b) => a.name < b.name ? -1 : 1)
-  return coins
+  return coins.filter(coin => coin.coin.toLowerCase() !== originCoin.toLowerCase())
 }
 
 export interface Pair {


### PR DESCRIPTION
Related to #187

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Adds logic to select coins using SideShift's API, displays their amount and the rate of conversion. 

This PR adds the logic for selecting the amount & currency to pay with, but **it doesn't yet implement the payment itself.** 

E.g, by selecting BTC and clicking "Pay with BTC", nothing will happen aside from a console.log of "WIP".

It's also important to notice that I didn't work in the design of the components, only their functionality. This PR lays ground for a frontend work to be done, with the goal of making the new  stuff more intuitive and agreeable for the eyes. 

Finally, it is also important to notice that this PR is off of a proxy branch, meaning approving and merging it won't commit anything to master (since it's incomplete). Nonetheless, it should be reviewed as if the changes here proposed are good enough (in what they propose to address) to eventually go to master (when all the changes are complete).


Test plan
---
For editable and non-editable paybuttons, there should be a "Don't have any XEC?" text which upon clicking will allow the user to select an alternative cryptocurrency to pay with.


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
