### PR TITLE
Fix/op return fail

### DIFF
--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -458,10 +458,6 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
       console.error(err);
       setErrorMsg((err as Error).message);
       setDisabled(true)
-      setTimeout((): void => {
-        setErrorMsg('')
-        setText(`Send any amount of ${addressType}`);
-      }, 5000);
     }
   }, [props.opReturn, paymentId, disablePaymentId]);
 


### PR DESCRIPTION
Related to #426 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fix opReturn fail behavior 


Test plan
---
create a button/widget with `op-return` prop set to a large string like this:
`"ABCDEFGHIJKLMNOPABCDEFlkfdnlkfndlksnkjsnfkldsnlknlksssssssss;sssssssssGHIJKLMNOPABCDEFGHIJKLMNOPABCDEFGHIJKLMNOPABCDEFGHIJKLMNOPABCDEFGHIJKLMNOPABCDEFGHIJKLMNOPABCDEFGHIJKLMNOPABCDEFGHIJKLMNOPABCDEFGHIJKLMNOP"`
the expected behavior is blur QR code and show the error message in console instead of in the button text. 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
