### PR TITLE
Feat/generator render widgets

### DIFF
--- a/paybutton/dev/demo/paybutton-generator.html
+++ b/paybutton/dev/demo/paybutton-generator.html
@@ -11,7 +11,8 @@
       }
 
       input,
-      button {
+      button,
+      select {
         padding: 8px;
         border-radius: 6px !important;
         border: 1px solid #ccc;
@@ -77,6 +78,13 @@
     <div id="playground">
       <form @submit.prevent="updateProps" class="card">
         <div>
+          <div class="form-input">
+            <label for="paybutton-type">Type:</label>
+            <select id="paybutton-type" v-model="paybuttonType" class="selector">
+              <option value="paybutton-widget">Widget</option>
+              <option value="paybutton">Button</option>
+            </select>
+          </div>
           <div class="form-input">
             <label for="to">To:</label>
             <input id="to" v-model="paybuttonProps.to" type="text">
@@ -178,7 +186,8 @@
           <div class="spinner"></div>
         </div>
         <div id="paybutton-generator-container">
-          <div id="paybutton-generator" class="paybutton"
+          <div id="paybutton-generator" 
+            :class="paybuttonType"
             :to="paybuttonProps.to"
             :amount="paybuttonProps.amount"
             :goal-amount="paybuttonProps.goalAmount"
@@ -204,7 +213,7 @@
     </div>
 
     <script>
-      const { createApp, reactive } = Vue;
+      const { createApp, reactive, ref } = Vue;
       const mySuccessFuction = (tx) => (console.log("Success", { tx }))
       const myTransactionFuction = (tx) => (console.log("Transaction", { tx }))
 
@@ -232,24 +241,32 @@
             onSuccess: mySuccessFuction,
             onTransaction: myTransactionFuction
           });
-
+          const paybuttonType = ref("paybutton-widget");
           const updateProps = () => {
-          const loadingOverlay = document.getElementById("loading-overlay");
-          const paybuttonGenerator = document.getElementById("paybutton-generator");
+            const loadingOverlay = document.getElementById("loading-overlay");
+            const paybuttonGenerator = document.getElementById("paybutton-generator");
 
 
-          loadingOverlay.style.display = "flex";
-          paybuttonGenerator.hidden = true
-          setTimeout(() => {
-            paybuttonGenerator.hidden = false
-            
-            PayButton.render(paybuttonGenerator, { ...paybuttonProps });
-            loadingOverlay.style.display = "none";
+            loadingOverlay.style.display = "flex";
+            paybuttonGenerator.hidden = true
 
-          }, 600);
-  };
+            setTimeout(() => {
+              paybuttonGenerator.hidden = false
+              switch (paybuttonType.value) {
+                case "paybutton-widget":
+                  PayButton.renderWidget(paybuttonGenerator, { ...paybuttonProps });
+                  break;
+                case "paybutton":
+                  PayButton.render(paybuttonGenerator, { ...paybuttonProps });
+                  break;
+              }
+              
+              loadingOverlay.style.display = "none";
 
-          return { paybuttonProps, updateProps };
+            }, 600);
+          };
+
+          return { paybuttonProps, updateProps, paybuttonType };
         }
       }).mount('#playground');
     </script>

--- a/paybutton/dev/demo/paybutton-generator.html
+++ b/paybutton/dev/demo/paybutton-generator.html
@@ -117,11 +117,15 @@
           </div>
           <div class="form-input">
             <label for="theme">Theme:</label>
-            <input id="theme" style="height: 100px;" v-model="paybuttonProps.theme" type="text">
+            <input id="theme" v-model="paybuttonProps.theme" type="text">
           </div>
           <div class="form-input">
             <label for="animation">Animation:</label>
             <input id="animation" v-model="paybuttonProps.animation" type="text">
+          </div>
+          <div class="form-input">
+            <label for="theme">Op Return:</label>
+            <input id="theme" v-model="paybuttonProps.opReturn" type="text">
           </div>
         </div>
         <div style="display: flex; flex-wrap: wrap; gap: 10px;">
@@ -192,7 +196,8 @@
             :disabled="paybuttonProps.disabled"
             :on-success="mySuccessFuction"
             :on-transaction="myTransactionFuction"
-            :enable-altpayment="paybuttonProps.enableAltpayment">
+            :enable-altpayment="paybuttonProps.enableAltpayment"
+            :op-return="paybuttonProps.opReturn">
           </div>
         </div>
       </div>
@@ -223,6 +228,7 @@
             disableEnforceFocus: false,
             enableAltpayment: false,
             contributionOffset: undefined,
+            opReturn:undefined,
             onSuccess: mySuccessFuction,
             onTransaction: myTransactionFuction
           });

--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -159,7 +159,11 @@ const useStyles = makeStyles({
       marginLeft: '4px',
       fontSize: '16px',
     }
-  }
+  },
+  error: () => ({
+    fontSize: '0.9rem !important',
+    color: '#EB3B3B !important',
+  }),
 });
 
 
@@ -451,8 +455,13 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
         }),
       );
     } catch (err) {
-      console.error((err as Error).message);
+      console.error(err);
+      setErrorMsg((err as Error).message);
       setDisabled(true)
+      setTimeout((): void => {
+        setErrorMsg('')
+        setText(`Send any amount of ${addressType}`);
+      }, 5000);
     }
   }, [props.opReturn, paymentId, disablePaymentId]);
 
@@ -621,7 +630,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
           textAlign="center"
         >
           {errorMsg ? (
-            <Typography className={classes.text} style={{ color: '#EB3B3B' }}>
+            <Typography className={classes.error}>
               {errorMsg}
             </Typography>
           ) : (

--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -451,7 +451,8 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
         }),
       );
     } catch (err) {
-      setErrorMsg((err as Error).message);
+      console.error((err as Error).message);
+      setDisabled(true)
     }
   }, [props.opReturn, paymentId, disablePaymentId]);
 


### PR DESCRIPTION
Related to #426 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Created a new field in the `generator.html` to select whether it will render a `paybutton` or a` paybutton-widget`. 

This change will help testing, before generator only rendered buttons now it can be used to widgets too.

Test plan
---
Run `yarn dev` access `http://localhost:10001/paybutton-generator.html` test generating widgets/buttons. 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
