### PR TITLE
fix: sideshift button not rendering

### DIFF
--- a/react/lib/components/Widget/AltpaymentWidget.tsx
+++ b/react/lib/components/Widget/AltpaymentWidget.tsx
@@ -186,7 +186,7 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
           copiedMessage.style.padding = "5px 0 5px 5px";
           copiedMessage.style.zIndex = "10";
           copiedMessage.style.display = "none";
-  
+
     if (contentElement) {
       const content = contentElement.textContent || "";
       navigator.clipboard.writeText(content);
@@ -344,7 +344,7 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
                     <div id="sideshift_id">{altpaymentShift.id}</div>
                     <img src={copyIcon} alt="Copy" onClick={() => copyToClipboard('sideshift_id')}/>
                   </div>
-                </div> 
+                </div>
               )
             ) : loadingShift ? (
               <p>Loading Shift...</p>
@@ -370,6 +370,7 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
                     Send {pairAmount} {selectedCoin?.name}
                   </Typography>
                 )}
+                <div></div>
                 <div style={loadingPair ||
                     selectedCoinNetwork === undefined ||
                     !pairAmount ||

--- a/react/lib/components/Widget/AltpaymentWidget.tsx
+++ b/react/lib/components/Widget/AltpaymentWidget.tsx
@@ -414,7 +414,7 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
                       <Select
                         labelId="select-coin-label"
                         className={classes.select_box}
-                        value={selectedCoin?.coin}
+                        value={selectedCoin?.coin ?? null}
                         onChange={e => {
                           handleCoinChange(e);
                         }}
@@ -453,7 +453,7 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
                             <Select
                               labelId="select-network-label"
                               className={classes.select_box}
-                              value={selectedCoinNetwork}
+                              value={selectedCoinNetwork ?? null}
                               onChange={e => {
                                 handleNetworkChange(e);
                               }}


### PR DESCRIPTION

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fixes issue where an editable amount paybutton wouldn't allow for the user to finish the process of paying with another currency.

Test plan
---
After selecting an altcoin, the button "Send with XYZ" wouldn't appear in master. In this branch, it should appear normally.


Remarks
---
- The change that makes it work is the empty `<div></div>` . I have no idea why is that so. Tried to figure out but decided not to spend too much time on that. My guess is something related to the new CSS, since this worked fine before.
- It seems that the "Don't have any XEC?" text doesn't appear if a button is of fixed amount (i.e; not editable). I will check this out in a next PR.
