### PR TITLE
fix: text empty nbsp

### DIFF
--- a/react/lib/components/Button/Button.tsx
+++ b/react/lib/components/Button/Button.tsx
@@ -129,7 +129,8 @@ export const Button = (props: ButtonProps): React.ReactElement => {
         onMouseLeave={handleMouseLeave}
         ref={buttonRef}
       >
-        <span>{transitioning !== hovering ? hoverText : text}</span>
+        
+        <span>{transitioning !== hovering ? hoverText : (text ? text : <div>&nbsp;</div>)}</span>
       </MuiButton>
     </div>
   );

--- a/react/lib/components/Button/Button.tsx
+++ b/react/lib/components/Button/Button.tsx
@@ -129,8 +129,8 @@ export const Button = (props: ButtonProps): React.ReactElement => {
         onMouseLeave={handleMouseLeave}
         ref={buttonRef}
       >
-        
-        <span>{transitioning !== hovering ? hoverText : (text ? text : <div>&nbsp;</div>)}</span>
+        <span> {transitioning !== hovering ? hoverText : (text && text.trim() !== "" ? text : <div>&nbsp;</div>)}
+        </span>
       </MuiButton>
     </div>
   );


### PR DESCRIPTION
Related to #428 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Added logic to render `<div>&nbsp;</div>` when text is empty string 


Test plan
---
Run the project with yarn dev and test the button with prop text=""

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
