### PR TITLE
feat: add inputs to tx type

### DIFF
--- a/react/lib/util/types.ts
+++ b/react/lib/util/types.ts
@@ -15,6 +15,7 @@ export interface Transaction {
     timestamp: number
     address: string
     rawMessage?: string
+    inputAddresses?: (string | undefined)[]
 }
 
 export interface UtxoDetails {


### PR DESCRIPTION
Related to #444 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Added input addresses to Transaction type 


Test plan
---
- Run server in this PR https://github.com/PayButton/paybutton-server/pull/917 
- Run client and set a callback (onSuccess or onTransaction) 
- Check if there are inputAddresses returned in the tx object. 
- Check if the inputAddresses matches the ones in the block explorer

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
