### PR TITLE
[UI]: Sideshift ui edits

### DIFF
--- a/react/lib/components/Widget/AltpaymentWidget.tsx
+++ b/react/lib/components/Widget/AltpaymentWidget.tsx
@@ -180,11 +180,14 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
     const copiedMessage = document.createElement("div");
           copiedMessage.textContent = "Copied!";
           copiedMessage.style.position = "absolute";
-          copiedMessage.style.width = "100%";
-          copiedMessage.style.top = "-5px";
+          copiedMessage.style.width = "calc(100% - 10px)";
+          copiedMessage.style.height = "calc(100% - 20px)";
+          copiedMessage.style.alignItems = "center";
+          copiedMessage.style.top = "0";
           copiedMessage.style.left = "0";
-          copiedMessage.style.backgroundColor = "rgb(232 232 237)";
-          copiedMessage.style.padding = "5px 0 5px 5px";
+          copiedMessage.style.backgroundColor = "#fff";
+          copiedMessage.style.borderRadius = "5px";
+          copiedMessage.style.padding = "10px 0 10px 10px";
           copiedMessage.style.zIndex = "10";
           copiedMessage.style.display = "none";
 
@@ -192,7 +195,7 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
       const content = contentElement.textContent || "";
       navigator.clipboard.writeText(content);
         contentElement.appendChild(copiedMessage);
-        copiedMessage.style.display = "inline-block";
+        copiedMessage.style.display = "flex";
 
         setTimeout(() => {
           copiedMessage.style.display = "none";
@@ -235,7 +238,9 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
       padding: '20px 0',
       alignItems: 'center',
       display: 'flex',
-      flexDirection: 'column'
+      flexDirection: 'column',
+      minHeight: '300px',
+      position: 'relative'
     },
     header: {
       marginBottom:'30px',
@@ -269,23 +274,16 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
       '& h4': {
        margin: '0',
        fontSize: '20px',
+       borderBottom: '1px solid #000',
+       paddingBottom: '10px',
+       textAlign: 'center',
       },
-      '& span': {
-        marginTop: '20px',
-        marginBottom: '2px',
-        fontSize: '16px',
-        fontWeight: '600'
-       },
     },
     copy_ctn: {
       display: 'flex',
       alignItems: 'center',
       '& > div': {
         position: 'relative'
-       },
-       '& img': {
-       width: '15px',
-       marginLeft: '5px'
        },
     },
     editAmount: {
@@ -300,6 +298,63 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
         marginLeft: '4px',
         fontSize: '16px',
       }
+    },
+    amount_error: {
+      position: 'absolute',
+      bottom: '10px',
+      textAlign: 'center',
+      background: '#00000014',
+      padding: '10px',
+      borderRadius: '5px'
+    },
+    error_msg: {
+      textAlign: 'center',
+      background: '#ee010119',
+      padding: '10px',
+      borderRadius: '5px',
+      color: 'red'
+    },
+    shift_label: {
+      fontSize: '14px',
+      marginLeft: '5px',
+      marginTop: '20px',
+      marginBottom: '2px',
+      fontWeight: 600
+    },
+    shift_input: {
+      background: '#ffffff',
+      padding: '10px',
+      borderRadius: '5px',
+      fontSize: '14px',
+      border: '1px solid #b3b3b3',
+      wordBreak: 'break-all',
+      flexGrow: 1,
+      position: 'relative',
+    },
+    copy_btn: {
+      background: '#ffffff',
+      padding: '10px',
+      borderRadius: '5px',
+      border: '1px solid #b3b3b3',
+      marginLeft: '5px',
+      display: 'flex',
+      alignItems: 'center',
+      cursor: 'pointer',
+      alignSelf: 'stretch',
+      '& hover': {
+        background: '#f1f1f1'
+      },
+      '& img': {
+        width: '15px',
+        },
+    },
+    shift_complete: {
+      display: 'flex',
+      alignItems: 'center',
+      height: '100%',
+      flex: '1',
+      width: '100%',
+      fontSize: '18px'
     }
   });
 
@@ -320,7 +375,7 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
     <div className={classes.sideshift_ctn}>
       {altpaymentError ? (
         <>
-          <p>Error: {altpaymentError.errorMessage}</p>
+          <p className={classes.error_msg}>Error: {altpaymentError.errorMessage}</p>
           <div className={classes.back_link} onClick={resetTrade}>Back</div>
         </>
       ) : (
@@ -328,23 +383,50 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
           {
             altpaymentShift ? (
               shiftCompleted ? (
-                <p>Shift Completed!</p>
+                <div className={classes.shift_complete}>Shift Completed!</div>
               ) : (
                 <div className={classes.shift_ready}>
                   <h4>Shift Ready!</h4>
-                  <span>Send</span>
-                  <div>{altpaymentShift.depositAmount}{' '}{altpaymentShift.depositCoin}</div>
-                  <span>To</span>
+                  <span className={classes.shift_label}>Send</span>
                   <div className={classes.copy_ctn}>
-                    <div id="to_address">{altpaymentShift.depositAddress}</div>
-                    <img src={copyIcon} alt="Copy" onClick={() => copyToClipboard('to_address')}/>
+                    <div className={classes.shift_input}>
+                      <span id="shift_amount">{altpaymentShift.depositAmount}</span>{' '}{altpaymentShift.depositCoin}
+                    </div>
+                    <div className={classes.copy_btn}>
+                      <img
+                        src={copyIcon}
+                        alt="Copy"
+                        onClick={() => copyToClipboard('shift_amount')}
+                      />
+                    </div>
                   </div>
-                  <span>Network</span>
-                  <div>{selectedCoinNetwork}</div>
-                  <span>SideShift ID</span>
+                  <span className={classes.shift_label}>To</span>
                   <div className={classes.copy_ctn}>
-                    <div id="sideshift_id">{altpaymentShift.id}</div>
-                    <img src={copyIcon} alt="Copy" onClick={() => copyToClipboard('sideshift_id')}/>
+                    <div id="to_address" className={classes.shift_input}>
+                      {altpaymentShift.depositAddress}
+                    </div>
+                    <div className={classes.copy_btn}>
+                      <img
+                        src={copyIcon}
+                        alt="Copy"
+                        onClick={() => copyToClipboard('to_address')}
+                      />
+                    </div>
+                  </div>
+                  <span className={classes.shift_label}>Network</span>
+                  <div className={classes.shift_input}>{selectedCoinNetwork}</div>
+                  <span className={classes.shift_label}>SideShift ID</span>
+                  <div className={classes.copy_ctn}>
+                    <div id="sideshift_id" className={classes.shift_input}>
+                      {altpaymentShift.id}
+                    </div>
+                    <div className={classes.copy_btn}>
+                      <img
+                        src={copyIcon}
+                        alt="Copy"
+                        onClick={() => copyToClipboard('sideshift_id')}
+                      />
+                    </div>
                   </div>
                 </div>
               )
@@ -364,12 +446,17 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
                     alignItems="flex-end"
                     style={{ margin: '6px auto' }}
                   >
-                    <Grid item xs={6}>
+                    <Grid item>
                       <TextField
                         label="Amount"
                         value={pairAmount ?? 0}
                         onChange={handlePairAmountChange}
-                        inputProps={{ maxLength: pairAmountMaxLength }}
+                        inputProps={{
+                          maxLength: pairAmountMaxLength,
+                          type: 'number',
+                          pattern: '[0-9]*',
+                          inputMode: 'numeric'
+                        }}
                       />
                     </Grid>
                   </Grid>
@@ -399,10 +486,10 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
                 />
                 </div>
                 {!isAboveMinimumAltpaymentAmount && (
-                  <p>Amount is below minimum.</p>
+                  <p className={classes.amount_error}>Amount is below minimum.</p>
                 )}
                 {!isBelowMaximumAltpaymentAmount && (
-                  <p>Amount is above maximum.</p>
+                  <p className={classes.amount_error}>Amount is above maximum.</p>
                 )}
               </>
             ) : (
@@ -486,7 +573,6 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
                     )}
                   </>
                 )}
-                <div className={classes.spacer} />
                 <div className={classes.spacer} />
                 {loadingPair ||
                 selectedCoin === undefined ||

--- a/react/lib/components/Widget/AltpaymentWidget.tsx
+++ b/react/lib/components/Widget/AltpaymentWidget.tsx
@@ -208,7 +208,7 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
 
   const useStyles = makeStyles({
     select_box: {
-      minWidth: '300px'
+      minWidth: '240px'
     },
     option_outer_ctn: {
       display: 'flex',
@@ -240,7 +240,9 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
       display: 'flex',
       flexDirection: 'column',
       minHeight: '300px',
-      position: 'relative'
+      position: 'relative',
+      minWidth: '240px',
+      maxWidth: '300px'
     },
     header: {
       marginBottom:'30px',
@@ -443,8 +445,9 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
                   <Grid
                     container
                     spacing={2}
-                    alignItems="flex-end"
-                    style={{ margin: '6px auto' }}
+                    alignItems="center"
+                    justifyContent="center"
+                    style={{ margin: '6px auto', width: '100%' }}
                   >
                     <Grid item>
                       <TextField

--- a/react/lib/components/Widget/AltpaymentWidget.tsx
+++ b/react/lib/components/Widget/AltpaymentWidget.tsx
@@ -239,7 +239,7 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
       alignItems: 'center',
       display: 'flex',
       flexDirection: 'column',
-      minHeight: '300px',
+      minHeight: '350px',
       position: 'relative',
       minWidth: '240px',
       maxWidth: '300px'
@@ -343,7 +343,8 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
       alignItems: 'center',
       cursor: 'pointer',
       alignSelf: 'stretch',
-      '& hover': {
+      transition: 'all ease-in-out 200ms',
+      '&:hover': {
         background: '#f1f1f1'
       },
       '& img': {
@@ -394,11 +395,10 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
                     <div className={classes.shift_input}>
                       <span id="shift_amount">{altpaymentShift.depositAmount}</span>{' '}{altpaymentShift.depositCoin}
                     </div>
-                    <div className={classes.copy_btn}>
+                    <div className={classes.copy_btn} onClick={() => copyToClipboard('shift_amount')}>
                       <img
                         src={copyIcon}
                         alt="Copy"
-                        onClick={() => copyToClipboard('shift_amount')}
                       />
                     </div>
                   </div>
@@ -407,11 +407,10 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
                     <div id="to_address" className={classes.shift_input}>
                       {altpaymentShift.depositAddress}
                     </div>
-                    <div className={classes.copy_btn}>
+                    <div className={classes.copy_btn} onClick={() => copyToClipboard('to_address')}>
                       <img
                         src={copyIcon}
                         alt="Copy"
-                        onClick={() => copyToClipboard('to_address')}
                       />
                     </div>
                   </div>
@@ -422,11 +421,10 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
                     <div id="sideshift_id" className={classes.shift_input}>
                       {altpaymentShift.id}
                     </div>
-                    <div className={classes.copy_btn}>
+                    <div className={classes.copy_btn} onClick={() => copyToClipboard('sideshift_id')}>
                       <img
                         src={copyIcon}
                         alt="Copy"
-                        onClick={() => copyToClipboard('sideshift_id')}
                       />
                     </div>
                   </div>

--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -147,8 +147,14 @@ const useStyles = makeStyles({
   sideShiftLink: ({ theme }: StyleProps) => ({
     fontSize: '14px',
     cursor: 'pointer',
+    padding: '6px 12px',
+    marginTop: '20px',
+    background: '#e9e9e9',
+    borderRadius: '5px',
+    transition: 'all ease-in-out 200ms',
     '&:hover': {
-      color: `${theme.palette.primary}`,
+      background: `${theme.palette.primary}`,
+      color: `${theme.palette.secondary}`,
     },
   }),
   editAmount: {
@@ -777,14 +783,8 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
                 </Box>
               )}
               {isPropsTrue(enableAltpayment) && (
-              <Box py={1}>
-                <Typography>
-                  {
-                    (isAboveMinimumAltpaymentUSDAmount || altpaymentEditable)   && <a className={classes.sideShiftLink} onClick={tradeWithAltpayment}>Don't have any {addressType}?</a>
-                  }
-                </Typography>
-              </Box>
-              )}
+              isAboveMinimumAltpaymentUSDAmount || altpaymentEditable)   && <a className={classes.sideShiftLink} onClick={tradeWithAltpayment}>Don't have any {addressType}?</a>
+              }
             </>
           }
           {foot && (


### PR DESCRIPTION
Related to #442

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
- Prevent non numerics in the input
- Improved copy buttons and shift value displays 
- style tweaks
- improve outer gray box jumping around. This one was is kind of tricky due to some of the widget's responsive size definitions for the qr inner content, which is not present here. So its better, but not perfect 
Test plan
---
preview and try out a shift 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
