### PR TITLE
fix: sideshift amount decimals

### DIFF
--- a/react/lib/components/Widget/AltpaymentWidget.tsx
+++ b/react/lib/components/Widget/AltpaymentWidget.tsx
@@ -11,7 +11,8 @@ import {
 } from '@material-ui/core';
 import {
   resolveNumber,
-  CryptoCurrency
+  CryptoCurrency,
+  DECIMALS
 } from '../../util';
 import { Button, animation } from '../Button/Button';
 import { Socket } from 'socket.io-client';
@@ -149,8 +150,11 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
     setPairAmount(pairAmount)
 
     if (coinPair !== undefined) {
-      const xecAmount = +coinPair.rate * +pairAmount
-      updateAmount(xecAmount.toString())
+      const settleCoinAmount = +coinPair.rate * +pairAmount
+
+      if(Object.keys(DECIMALS).includes(coinPair.settleCoin)){
+        updateAmount(settleCoinAmount.toFixed(DECIMALS[coinPair.settleCoin]))
+      }
     }
   };
 
@@ -437,7 +441,7 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
                 <p>
                   {' '}
                   1 {selectedCoin?.name} ~={' '}
-                  {resolveNumber(coinPair.rate).toFixed(2)} XEC{' '}
+                  {resolveNumber(coinPair.rate).toFixed(DECIMALS[coinPair.settleCoin])} {coinPair.settleCoin}{' '}
                 </p>
                 {altpaymentEditable ? (
                   <Grid

--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -522,7 +522,6 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
     if (addressType === 'XEC') {
       const hasExtension = getCashtabProviderStatus();
       if (!hasExtension) {
-        window.location.href = url;
         const isMobile = window.matchMedia('(pointer:coarse)').matches;
         if (isMobile) {
           window.location.href = `https://cashtab.com/#/send?bip21=${url}`;


### PR DESCRIPTION
Related to #448 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fixed decimals and settleCoin name 
Fixed decimals of settleCoin 


Test plan
---
- Create a paybutton with both BCH/XEC addresses and check the following behavior -> 
go to sideshift > choose a coin > click `Send with sideshift` > set an amount > go back > go back 

check if the amount is set with correct number of decimals. 


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
