### PR TITLE
ui: prevent disabled button on non editable amount sideshift

### DIFF
--- a/react/lib/components/Widget/AltpaymentWidget.tsx
+++ b/react/lib/components/Widget/AltpaymentWidget.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import {
-  Typography,
   TextField,
   Grid,
   Select,
@@ -466,14 +465,12 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
                     </Grid>
                   </Grid>
                 ) : (
-                  <Typography>
-                    Send {pairAmount} {selectedCoin?.name}
-                  </Typography>
+                  null
                 )}
                 <div></div>
                 <div style={loadingPair ||
                     selectedCoinNetwork === undefined ||
-                    !pairAmount ||
+                    (altpaymentEditable && !pairAmount) ||
                     !isAboveMinimumAltpaymentAmount ||
                     !isBelowMaximumAltpaymentAmount ? {opacity: '0.5', cursor: 'not-allowed'} : {}}>
                 <Button
@@ -483,7 +480,7 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
                   disabled={
                     loadingPair ||
                     selectedCoinNetwork === undefined ||
-                    !pairAmount ||
+                    (altpaymentEditable && !pairAmount) ||
                     !isAboveMinimumAltpaymentAmount ||
                     !isBelowMaximumAltpaymentAmount
                   }


### PR DESCRIPTION
Related to #187 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Prevent the button in the sideshift flow from being disabled if the paybutton amount is not editable. 

My understanding is 'pairAmount' is not used if 'altpaymentEditable' is not enabled. Its coming in undefined, so just ignoring it if its not altpaymentEditable 


Test plan
---
Try out the sideshift with a editable and non editable amount button 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
