### PR TITLE
ui: Make SideShift container same size as widget 

### DIFF
--- a/react/lib/components/Widget/AltpaymentWidget.tsx
+++ b/react/lib/components/Widget/AltpaymentWidget.tsx
@@ -211,7 +211,7 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
 
   const useStyles = makeStyles({
     select_box: {
-      minWidth: '240px'
+      minWidth: '220px'
     },
     option_outer_ctn: {
       display: 'flex',

--- a/react/lib/components/Widget/AltpaymentWidget.tsx
+++ b/react/lib/components/Widget/AltpaymentWidget.tsx
@@ -238,14 +238,17 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
       height: '20px'
     },
     sideshift_ctn: {
-      padding: '20px 0',
       alignItems: 'center',
       display: 'flex',
       flexDirection: 'column',
-      minHeight: '350px',
-      position: 'relative',
-      minWidth: '240px',
-      maxWidth: '300px'
+      height: 'calc(100% - 20px)',
+      width: '100%',
+      position: 'absolute',
+      zIndex: 9,
+      top: '0',
+      left: '0',
+      background: '#f5f5f7',
+      paddingTop: '20px'
     },
     header: {
       marginBottom:'30px',

--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -90,6 +90,7 @@ const useStyles = makeStyles({
   root: {
     minWidth: '240px !important',
     background: '#f5f5f7 !important',
+    position: 'relative',
   },
   qrCode: ({ success, loading, theme }: StyleProps) => ({
     background: '#fff !important',
@@ -651,9 +652,10 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
           alignItems="center"
           px={3}
           pt={2}
+          position="relative"
         >
           {// Altpayment region
-            useAltpayment ?
+            useAltpayment &&
               <AltpaymentWidget
                 altpaymentSocket={altpaymentSocket}
                 thisAmount={thisAmount}
@@ -677,7 +679,8 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
                 addressType={addressType}
                 to={to}
               />
-               : <>
+           }
+            <>
               {loading && shouldDisplayGoal ? (
                 <Typography
                   className={classes.text}
@@ -786,7 +789,6 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
               isAboveMinimumAltpaymentUSDAmount || altpaymentEditable)   && <a className={classes.sideShiftLink} onClick={tradeWithAltpayment}>Don't have any {addressType}?</a>
               }
             </>
-          }
           {foot && (
             <Box pt={2} flex={1}>
               {foot}

--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -786,8 +786,14 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
                 </Box>
               )}
               {isPropsTrue(enableAltpayment) && (
-              isAboveMinimumAltpaymentUSDAmount || altpaymentEditable)   && <a className={classes.sideShiftLink} onClick={tradeWithAltpayment}>Don't have any {addressType}?</a>
-              }
+                <a
+                  className={classes.sideShiftLink}
+                  onClick={tradeWithAltpayment}
+                  style={{ opacity: isAboveMinimumAltpaymentUSDAmount || altpaymentEditable ? 1 : 0 }}
+                >
+                  Don't have any {addressType}?
+                </a>
+              )}
             </>
           {foot && (
             <Box pt={2} flex={1}>


### PR DESCRIPTION
Related to #

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Moving the sideshift content to be absolutely positioned so its always the same exact size as the widget to prevent any jumping 


Test plan
---
Try some shifts

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
