### PR TITLE
fix sideshift button when opacity 0

### DIFF
--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -786,13 +786,16 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
                 </Box>
               )}
               {!isPropsTrue(disableAltpayment) && (
-                <a
+                <div
                   className={classes.sideShiftLink}
-                  onClick={tradeWithAltpayment}
-                  style={{ opacity: isAboveMinimumAltpaymentUSDAmount || altpaymentEditable ? 1 : 0 }}
+                  onClick={isAboveMinimumAltpaymentUSDAmount || altpaymentEditable ? tradeWithAltpayment : undefined}
+                  style={{
+                    opacity: isAboveMinimumAltpaymentUSDAmount || altpaymentEditable ? 1 : 0,
+                    cursor: isAboveMinimumAltpaymentUSDAmount || altpaymentEditable ? 'pointer' : 'default'
+                  }}
                 >
                   Don't have any {addressType}?
-                </a>
+                </div>
               )}
             </>
           {foot && (


### PR DESCRIPTION
Related to #

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
The button when disabled (aka invisible) was still clickable. Fixing that here


Test plan
---
preview and try clicking an invisible button 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
