### PR TITLE
ui: fix fonts not coming through

### DIFF
--- a/react/lib/components/Widget/AltpaymentWidget.tsx
+++ b/react/lib/components/Widget/AltpaymentWidget.tsx
@@ -6,7 +6,8 @@ import {
   MenuItem,
   makeStyles,
   InputLabel,
-  FormControl
+  FormControl,
+  Typography
 } from '@material-ui/core';
 import {
   resolveNumber,
@@ -381,7 +382,7 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
   }
 
   return (
-    <div className={classes.sideshift_ctn}>
+    <Typography component="div" className={classes.sideshift_ctn}>
       {altpaymentError ? (
         <>
           <p className={classes.error_msg}>Error: {altpaymentError.errorMessage}</p>
@@ -604,7 +605,7 @@ export const AltpaymentWidget: React.FunctionComponent<AltpaymentProps> = props 
             )}
         </>
       )}
-    </div>
+    </Typography>
   );
 };
 

--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -770,7 +770,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
                     placeholder='Enter Amount'
                     id="userEditedAmount"
                   />
-                  <span>{currency}</span>
+                 <Typography component="span">{currency}</Typography>
                 </div>
               )}
 
@@ -786,7 +786,8 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
                 </Box>
               )}
               {!isPropsTrue(disableAltpayment) && (
-                <div
+                <Typography
+                  component="div"
                   className={classes.sideShiftLink}
                   onClick={isAboveMinimumAltpaymentUSDAmount || altpaymentEditable ? tradeWithAltpayment : undefined}
                   style={{
@@ -795,7 +796,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
                   }}
                 >
                   Don't have any {addressType}?
-                </div>
+                </Typography>
               )}
             </>
           {foot && (


### PR DESCRIPTION
Related to #

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fixing the font family not being applied on the edit amount ticker and the sideshift button and container


Test plan
---
Preview the site and try changing the body font-family to 'serif' in the inspector and see if the sideshift button changes font or not. (it should not) 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
