### PR TITLE
fix: open cashtab web case

### DIFF
--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -523,13 +523,8 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
     if (addressType === 'XEC') {
       const hasExtension = getCashtabProviderStatus();
       if (!hasExtension) {
-        const isMobile = window.matchMedia('(pointer:coarse)').matches;
-        if (isMobile) {
-          const webUrl = `https://cashtab.com/#/send?bip21=${url}`;
-          window.open(webUrl, '_blank');
-        } else {
-          window.location.href = url;
-        }
+        const webUrl = `https://cashtab.com/#/send?bip21=${url}`;
+        window.open(webUrl, '_blank');
       } else {
         return window.postMessage(
           {


### PR DESCRIPTION
Related to #464 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Open cashtab.com when ElectrumABC and Cashtab Extension is not installed 


Test plan
---
Run `yarn dev`, test send button with ElectrumABC and Cashtab Extension not installed 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
