### PR TITLE
feat: transaction text prop

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -560,7 +560,7 @@ successText = "Thanks!"
 
 ## transaction-text
 
-> **The ‘transaction-text’ parameter specifies the text displayed when a new transaction occurs.**
+> **The ‘transaction-text’ parameter specifies the text displayed when a new transaction occurs but the amount or OP_RETURN code are incorrect.**
 
 ?> This parameter is optional. Default value is empty. Possible values are any string.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -558,6 +558,35 @@ successText = "Thanks!"
 
 <!-- tabs:end -->
 
+## transaction-text
+
+> **The ‘transaction-text’ parameter specifies the text displayed when a new transaction occurs.**
+
+?> This parameter is optional. Default value is empty. Possible values are any string.
+
+**Example:**
+<!-- tabs:start -->
+
+#### ** HTML **
+
+```html
+transaction-text="New transaction!"
+```
+
+#### ** JavaScript **
+
+```javascript
+transactionText: 'New transaction!'
+```
+
+#### ** React **
+
+```react
+transactionText = "New transaction!"
+```
+
+<!-- tabs:end -->
+
 ## on-success
 
 > **The ‘on-success’ parameter specifies the callback function that runs upon successful payment.**
@@ -927,6 +956,8 @@ apiBaseUrl: 'https://paybutton.org'
 ```react
 apiBaseUrl = "https://paybutton.org"
 ```
+
+<!-- tabs:end -->
 
 ## disable-altpayment
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -15,6 +15,7 @@
   - [theme](/?id=theme)
   - [animation](/?id=animation)
   - [success-text](/?id=success-text)
+  - [transaction-text](/?id=transaction-text)
   - [on-success](/?id=on-success)
   - [on-transaction](/?id=on-transaction)
   - [on-open](/?id=on-open)

--- a/docs/zh-cn/README.md
+++ b/docs/zh-cn/README.md
@@ -555,7 +555,7 @@ successText = "Thanks!"
 
 ## transaction-text
 
-> **“transaction-text” 参数指定在新交易发生时显示的文本。**
+> **“transaction-text” 参数指定当发生新交易但金额或 OP_RETURN 代码不正确时显示的文本。**
 
 ?> 此参数为选填，默认值为空。可用值为任何字符串。
 

--- a/docs/zh-cn/README.md
+++ b/docs/zh-cn/README.md
@@ -553,6 +553,37 @@ successText = "Thanks!"
 
 <!-- tabs:end -->
 
+## transaction-text
+
+> **“transaction-text” 参数指定在新交易发生时显示的文本。**
+
+?> 此参数为选填，默认值为空。可用值为任何字符串。
+
+**Example:**
+<!-- tabs:start -->
+
+#### ** HTML **
+
+```html
+transaction-text="New transaction!"
+```
+
+#### ** JavaScript **
+
+```javascript
+transactionText: 'New transaction!'
+```
+
+#### ** React **
+
+```react
+transactionText = "New transaction!"
+```
+
+<!-- tabs:end -->
+
+
+
 ## on-success
 
 > **参数'on-success'用来定义指定地址收款后运行的回调函数。**

--- a/docs/zh-cn/_sidebar.md
+++ b/docs/zh-cn/_sidebar.md
@@ -14,6 +14,7 @@
   - [theme](/zh-cn/?id=theme)
   - [animation](/zh-cn/?id=animation)
   - [success-text](/zh-cn/?id=success-text)
+  - [transaction-text](/zh-cn/?id=transaction-text)
   - [on-success](/zh-cn/?id=on-success)
   - [on-transaction](/zh-cn/?id=on-transaction)
   - [on-open](/zh-cn/?id=on-open)

--- a/docs/zh-tw/README.md
+++ b/docs/zh-tw/README.md
@@ -553,6 +553,36 @@ successText = "Thanks!"
 
 <!-- tabs:end -->
 
+## transaction-text
+
+> **"transaction-text" 參數指定在新交易發生時顯示的文字。**
+
+?> 此參數為選填，預設值為空。可用值為任何字串。
+
+**Example:**
+<!-- tabs:start -->
+
+#### ** HTML **
+
+```html
+transaction-text="New transaction!"
+```
+
+#### ** JavaScript **
+
+```javascript
+transactionText: 'New transaction!'
+```
+
+#### ** React **
+
+```react
+transactionText = "New transaction!"
+```
+
+<!-- tabs:end -->
+
+
 ## on-success
 
 > **參數"on-success"用來定義指定地址收款後運行的回呼函式。**

--- a/docs/zh-tw/README.md
+++ b/docs/zh-tw/README.md
@@ -555,7 +555,7 @@ successText = "Thanks!"
 
 ## transaction-text
 
-> **"transaction-text" 參數指定在新交易發生時顯示的文字。**
+> **"transaction-text"  參數指定當發生新交易但金額或 OP_RETURN 代碼不正確時顯示的文字。**
 
 ?> 此參數為選填，預設值為空。可用值為任何字串。
 

--- a/docs/zh-tw/_sidebar.md
+++ b/docs/zh-tw/_sidebar.md
@@ -14,6 +14,7 @@
   - [theme](/zh-tw/?id=theme)
   - [animation](/zh-tw/?id=animation)
   - [success-text](/zh-tw/?id=success-text)
+  - [ transaction-text](/zh-tw/?id=transaction-text)
   - [on-success](/zh-tw/?id=on-success)
   - [on-transaction](/zh-tw/?id=on-transaction)
   - [on-open](/zh-tw/?id=on-open)

--- a/paybutton/dev/demo/paybutton-generator.html
+++ b/paybutton/dev/demo/paybutton-generator.html
@@ -119,9 +119,15 @@
               <input id="successText" v-model="paybuttonProps.successText" type="text">
             </div>
           </div>
-          <div class="form-input">
-            <label for="hoverText">Hover Text:</label>
-            <input id="hoverText" v-model="paybuttonProps.hoverText" type="text">
+          <div style="display: flex; justify-content: space-between; gap:10px">
+            <div class="form-input">
+              <label for="hoverText">Hover Text:</label>
+              <input id="hoverText" v-model="paybuttonProps.hoverText" type="text">
+            </div>
+            <div class="form-input">
+              <label for="transactionText">Transaction Text:</label>
+              <input id="transactionText" v-model="paybuttonProps.transactionText" type="text">
+            </div>
           </div>
           <div class="form-input">
             <label for="theme">Theme:</label>
@@ -206,6 +212,7 @@
             :on-success="mySuccessFuction"
             :on-transaction="myTransactionFuction"
             :disable-altpayment="paybuttonProps.disableAltpayment"
+            :transaction-text="paybuttonProps.transactionText"
             :op-return="paybuttonProps.opReturn">
           </div>
         </div>
@@ -238,6 +245,7 @@
             disableAltpayment: false,
             contributionOffset: undefined,
             opReturn:undefined,
+            transactiontext: '',
             onSuccess: mySuccessFuction,
             onTransaction: myTransactionFuction
           });

--- a/paybutton/src/index.tsx
+++ b/paybutton/src/index.tsx
@@ -103,6 +103,7 @@ const allowedProps = [
   'contributionOffset',
   'autoClose',
   'disableSound',
+  'transactionText',
 ];
 
 const requiredProps = [

--- a/react/lib/components/PayButton/PayButton.tsx
+++ b/react/lib/components/PayButton/PayButton.tsx
@@ -43,10 +43,11 @@ export interface PayButtonProps extends ButtonProps {
   onClose?: (success?: boolean, paymentId?:string) => void;
   wsBaseUrl?: string;
   apiBaseUrl?: string;
-  disableAltpayment?: boolean
-  contributionOffset?: number
-  autoClose?: boolean
   disableSound?: boolean
+  autoClose?: boolean;
+  disableAltpayment?:boolean;
+  contributionOffset?:number;
+  transactionText?: string;
 }
 
 export const PayButton = (props: PayButtonProps): React.ReactElement => {
@@ -85,6 +86,7 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
     contributionOffset,
     autoClose,
     disableSound,
+    transactionText,
   } = Object.assign({}, PayButton.defaultProps, props);
 
   const [paymentId] = useState(!disablePaymentId ? generatePaymentId(8) : undefined);
@@ -242,6 +244,7 @@ export const PayButton = (props: PayButtonProps): React.ReactElement => {
         contributionOffset={contributionOffset}
         autoClose={autoClose}
         disableSound={disableSound}
+        transactionText={transactionText}
       />
       {errorMsg && (
         <p

--- a/react/lib/components/PaymentDialog/PaymentDialog.tsx
+++ b/react/lib/components/PaymentDialog/PaymentDialog.tsx
@@ -35,9 +35,10 @@ export interface PaymentDialogProps extends ButtonProps {
   wsBaseUrl?: string;
   apiBaseUrl?: string;
   disableAltpayment?: boolean;
-  contributionOffset?: number;
-  autoClose?: boolean;
   disableSound?: boolean;
+  autoClose?: boolean;
+  contributionOffset?:number;
+  transactionText?: string
 }
 
 export const PaymentDialog = (
@@ -77,6 +78,7 @@ export const PaymentDialog = (
     contributionOffset,
     autoClose,
     disableSound,
+    transactionText,
   } = Object.assign({}, PaymentDialog.defaultProps, props);
 
   const handleWidgetClose = (): void => {
@@ -157,6 +159,7 @@ export const PaymentDialog = (
           disableAltpayment={disableAltpayment}
           contributionOffset={contributionOffset}
           disableSound={disableSound}
+          transactionText={transactionText}
           foot={success && (
             <ButtonComponent
               onClick={handleWidgetClose}

--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -80,6 +80,7 @@ export interface WidgetProps {
   disableAltpayment?: boolean;
   contributionOffset?: number;
   newTxText?: string;
+  transactionText?: string;
 }
 
 interface StyleProps {
@@ -311,8 +312,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
     shiftCompleted,
     setShiftCompleted,
     disableAltpayment,
-    contributionOffset,
-    newTxText
+    contributionOffset
   } = Object.assign({}, Widget.defaultProps, props);
 
   const [loading, setLoading] = useState(true);
@@ -756,7 +756,6 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
               if (disabled) return 'Not yet ready for payment';
               if (loading) return 'Loading...';
               if (success) return successText;
-              if (newTxText) return newTxText;       
               return text;
             })()}
         </Typography>

--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -78,7 +78,8 @@ export interface WidgetProps {
   shiftCompleted: boolean
   setShiftCompleted: Function;
   disableAltpayment?: boolean;
-  contributionOffset?: number
+  contributionOffset?: number;
+  newTxText?: string;
 }
 
 interface StyleProps {
@@ -310,7 +311,8 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
     shiftCompleted,
     setShiftCompleted,
     disableAltpayment,
-    contributionOffset
+    contributionOffset,
+    newTxText
   } = Object.assign({}, Widget.defaultProps, props);
 
   const [loading, setLoading] = useState(true);
@@ -754,6 +756,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
               if (disabled) return 'Not yet ready for payment';
               if (loading) return 'Loading...';
               if (success) return successText;
+              if (newTxText) return newTxText;       
               return text;
             })()}
         </Typography>

--- a/react/lib/components/Widget/WidgetContainer.tsx
+++ b/react/lib/components/Widget/WidgetContainer.tsx
@@ -48,6 +48,7 @@ export interface WidgetContainerProps
   disableAltpayment?: boolean
   contributionOffset?: number
   disableSound?: boolean
+  transactionText?: string
 }
 
 const snackbarOptions: OptionsObject = {
@@ -109,6 +110,7 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
       disableAltpayment,
       contributionOffset,
       disableSound,
+      transactionText,
       ...widgetProps
     } = props;
 
@@ -130,6 +132,7 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
     const [useAltpayment, setUseAltpayment] = useState(false);
     const [altpaymentShift, setAltpaymentShift] = useState<AltpaymentShift | undefined>();
     const [shiftCompleted, setShiftCompleted] = useState(false);
+    const [newTxText, setNewTxText] = useState('');
 
     const paymentClient = getAltpaymentClient()
 
@@ -192,6 +195,13 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
             }, 3000);
           } else {
             onTransaction?.(transaction);
+            if (transactionText){
+              setNewTxText(transactionText)
+              setTimeout(() => {
+                setNewTxText('')
+              }, 10000)
+            }
+            
           }
         }
         setNewTxs([]);
@@ -286,6 +296,7 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
           setShiftCompleted={setShiftCompleted}
           disableAltpayment={disableAltpayment}
           contributionOffset={contributionOffset}
+          newTxText={newTxText}
         />
       </React.Fragment>
     );

--- a/react/lib/components/Widget/WidgetContainer.tsx
+++ b/react/lib/components/Widget/WidgetContainer.tsx
@@ -51,8 +51,16 @@ export interface WidgetContainerProps
   transactionText?: string
 }
 
-const snackbarOptions: OptionsObject = {
+const snackbarOptionsSuccess: OptionsObject = {
   variant: 'success',
+  autoHideDuration: 8000,
+  anchorOrigin: {
+    vertical: 'bottom',
+    horizontal: 'center',
+  },
+};
+
+const snackbarOptionsInfo: OptionsObject = {
   autoHideDuration: 8000,
   anchorOrigin: {
     vertical: 'bottom',
@@ -132,7 +140,6 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
     const [useAltpayment, setUseAltpayment] = useState(false);
     const [altpaymentShift, setAltpaymentShift] = useState<AltpaymentShift | undefined>();
     const [shiftCompleted, setShiftCompleted] = useState(false);
-    const [newTxText, setNewTxText] = useState('');
 
     const paymentClient = getAltpaymentClient()
 
@@ -161,6 +168,7 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
         } else {
           const expectedAmount = amount ? resolveNumber(amount) : undefined;
           const receivedAmount = resolveNumber(transaction.amount);
+          const currencyTicker = getCurrencyTypeFromAddress(to);
 
           if (await shouldTriggerOnSuccess(
             transaction,
@@ -180,13 +188,12 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
               txSound.play().catch(() => {});
             }
 
-            const currencyTicker = getCurrencyTypeFromAddress(to);
             if (!hideToasts)
               enqueueSnackbar(
                 `${
                   successText ? successText + ' | ' : ''
                 }Received ${receivedAmount} ${currencyTicker}`,
-                snackbarOptions,
+                snackbarOptionsSuccess,
               );
             setSuccess(true);
             onSuccess?.(transaction);
@@ -196,10 +203,12 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
           } else {
             onTransaction?.(transaction);
             if (transactionText){
-              setNewTxText(transactionText)
-              setTimeout(() => {
-                setNewTxText('')
-              }, 10000)
+              enqueueSnackbar(
+                `${
+                  transactionText ? transactionText : 'New transaction'
+                } | Received ${receivedAmount} ${currencyTicker}`,
+                snackbarOptionsInfo,
+              );
             }
             
           }
@@ -296,7 +305,7 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
           setShiftCompleted={setShiftCompleted}
           disableAltpayment={disableAltpayment}
           contributionOffset={contributionOffset}
-          newTxText={newTxText}
+          transactionText={transactionText}
         />
       </React.Fragment>
     );


### PR DESCRIPTION
Related to #270 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Added the `transaction-text` prop. The `transaction-text` will be displayed in the widget when a transaction occurs, but the amount does not match the required amount, preventing a success message. 


Test plan
---
- Add transaction-text prop in a paybutton and widget 
- Test transact-text in paybutton generator

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
