### PR TITLE
fix: altpayment not showing up

### DIFF
--- a/react/lib/altpayment/index.ts
+++ b/react/lib/altpayment/index.ts
@@ -3,6 +3,8 @@ import { SideshiftClient, SideshiftCoin, SideshiftError, SideshiftPair, Sideshif
 import config from '../../../paybutton-config.json'
 
 export const MINIMUM_ALTPAYMENT_DOLLAR_AMOUNT = 10
+export const MINIMUM_ALTPAYMENT_CAD_AMOUNT = 15
+
 
 export const SOCKET_MESSAGES = {
   GET_ALTPAYMENT_RATE: 'get-altpayment-rate',

--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -37,7 +37,7 @@ import {
   isPropsTrue
 } from '../../util';
 import AltpaymentWidget from './AltpaymentWidget';
-import { AltpaymentPair, AltpaymentShift, AltpaymentError, AltpaymentCoin, MINIMUM_ALTPAYMENT_DOLLAR_AMOUNT } from '../../altpayment';
+import { AltpaymentPair, AltpaymentShift, AltpaymentError, AltpaymentCoin, MINIMUM_ALTPAYMENT_DOLLAR_AMOUNT, MINIMUM_ALTPAYMENT_CAD_AMOUNT } from '../../altpayment';
 
 type QRCodeProps = BaseQRCodeProps & { renderAs: 'svg' };
 
@@ -341,7 +341,7 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
   const [loadingShift, setLoadingShift] = useState(false);
   const [altpaymentError, setAltpaymentError] = useState<AltpaymentError | undefined>(undefined);
   const [altpaymentEditable, setAltpaymentEditable] = useState<boolean>(false);
-  const [isAboveMinimumAltpaymentUSDAmount, setIsAboveMinimumAltpaymentUSDAmount] = useState<boolean | null>(null);
+  const [isAboveMinimumAltpaymentAmount, setIsAboveMinimumAltpaymentAmount] = useState<boolean | null>(null);
 
   const theme = useTheme(props.theme, isValidXecAddress(to));
   const classes = useStyles({ success, loading, theme, recentlyCopied, copied });
@@ -477,7 +477,17 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
     }
     if (usdPrice && thisAmount) {
       const usdAmount = usdPrice * +thisAmount
-      setIsAboveMinimumAltpaymentUSDAmount(usdAmount >= MINIMUM_ALTPAYMENT_DOLLAR_AMOUNT)
+      setIsAboveMinimumAltpaymentAmount(usdAmount >= MINIMUM_ALTPAYMENT_DOLLAR_AMOUNT)
+    } else if (currency === 'USD'){
+      if (thisAmount && +thisAmount > MINIMUM_ALTPAYMENT_DOLLAR_AMOUNT){
+        setIsAboveMinimumAltpaymentAmount(true)
+      }
+
+    } else if (currency === 'CAD'){
+      if (thisAmount && +thisAmount > MINIMUM_ALTPAYMENT_CAD_AMOUNT){
+        setIsAboveMinimumAltpaymentAmount(true)
+      }
+
     }
   }, [to, thisAmount, usdPrice]);
 
@@ -889,9 +899,9 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
               {!isPropsTrue(disableAltpayment) && (
                 <Typography
                   component="div"
-                  className={`${classes.sideShiftLink} ${isAboveMinimumAltpaymentUSDAmount || altpaymentEditable ? classes.animate_sideshift : classes.hide_sideshift}`}
-                  onClick={isAboveMinimumAltpaymentUSDAmount || altpaymentEditable ? tradeWithAltpayment : undefined}
-                  style={{cursor: isAboveMinimumAltpaymentUSDAmount || altpaymentEditable ? 'pointer' : 'default'}}
+                  className={`${classes.sideShiftLink} ${isAboveMinimumAltpaymentAmount || altpaymentEditable ? classes.animate_sideshift : classes.hide_sideshift}`}
+                  onClick={isAboveMinimumAltpaymentAmount || altpaymentEditable ? tradeWithAltpayment : undefined}
+                  style={{cursor: isAboveMinimumAltpaymentAmount || altpaymentEditable ? 'pointer' : 'default'}}
                 >
                   Don't have any {addressType}?
                 </Typography>

--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -479,12 +479,12 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
       const usdAmount = usdPrice * +thisAmount
       setIsAboveMinimumAltpaymentAmount(usdAmount >= MINIMUM_ALTPAYMENT_DOLLAR_AMOUNT)
     } else if (currency === 'USD'){
-      if (thisAmount && +thisAmount > MINIMUM_ALTPAYMENT_DOLLAR_AMOUNT){
+      if (thisAmount && +thisAmount >= MINIMUM_ALTPAYMENT_DOLLAR_AMOUNT){
         setIsAboveMinimumAltpaymentAmount(true)
       }
 
     } else if (currency === 'CAD'){
-      if (thisAmount && +thisAmount > MINIMUM_ALTPAYMENT_CAD_AMOUNT){
+      if (thisAmount && +thisAmount >= MINIMUM_ALTPAYMENT_CAD_AMOUNT){
         setIsAboveMinimumAltpaymentAmount(true)
       }
 


### PR DESCRIPTION
Related to #460 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Fixed altpayment not showing up when currency is declared 


Test plan
---
create a button with currency set and an amount higher than $10, altpayment option should show up

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
