### PR TITLE
feat: ignore opReturn bch

### DIFF
--- a/react/lib/util/address.ts
+++ b/react/lib/util/address.ts
@@ -49,7 +49,7 @@ const removeAddressPrefix = function (addressString: string): string {
 
 type NetworkSlugsType = 'ecash' | 'bitcoincash'
 
-const getAddressPrefix = function (addressString: string): NetworkSlugsType {
+export const getAddressPrefix = function (addressString: string): NetworkSlugsType {
   try {
     const format = xecaddr.detectAddressFormat(addressString)
     if (format === xecaddr.Format.Xecaddr) {

--- a/react/lib/util/validate.ts
+++ b/react/lib/util/validate.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import { getCurrencyTypeFromAddress } from "./address";
+import { getAddressPrefix, getCurrencyTypeFromAddress } from "./address";
 import { resolveNumber } from "./number";
 import { Currency, CurrencyObject, Transaction } from "./types";
 import { DECIMALS } from "./constants";
@@ -20,7 +20,9 @@ export const shouldTriggerOnSuccess = async (
       message,
       amount, 
       address } = transaction; 
-      
+    
+    const addressPrefix = getAddressPrefix(address);
+    const isBCH = addressPrefix === 'bitcoincash';
     let isAmountValid = true;
 
     if(expectedAmount) {
@@ -40,12 +42,15 @@ export const shouldTriggerOnSuccess = async (
     const paymentIdsMatch = expectedPaymentId === paymentId;
     const isPaymentIdValid = disablePaymentId ? true : paymentIdsMatch;
 
-    const rawOpReturnIsEmptyOrUndefined = rawOpReturn === '' || rawOpReturn === undefined;
-    const opReturn = rawOpReturnIsEmptyOrUndefined ? message : rawOpReturn
-    const opReturnIsEmptyOrUndefined = opReturn === '' || opReturn === undefined;
-  
-    const opReturnsMatch = opReturn === expectedOpReturn;
-    const isOpReturnValid = expectedOpReturn ? opReturnsMatch : opReturnIsEmptyOrUndefined;
+    let isOpReturnValid = true;
+    if(!isBCH){
+      const rawOpReturnIsEmptyOrUndefined = rawOpReturn === '' || rawOpReturn === undefined;
+      const opReturn = rawOpReturnIsEmptyOrUndefined ? message : rawOpReturn
+      const opReturnIsEmptyOrUndefined = opReturn === '' || opReturn === undefined;
+    
+      const opReturnsMatch = opReturn === expectedOpReturn;
+      isOpReturnValid = expectedOpReturn ? opReturnsMatch : opReturnIsEmptyOrUndefined;
+    }
     
     return isAmountValid && isPaymentIdValid && isOpReturnValid;
 };


### PR DESCRIPTION
Related to #379 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Ignore Op return trigger success validation on bch transactions 


Test plan
---
Check if button is triggering success on BCH transactions with wrong OP_RETURN


<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
