### PR TITLE
Feat/autoclose false default

### DIFF
--- a/paybutton/dev/demo/paybutton-generator.html
+++ b/paybutton/dev/demo/paybutton-generator.html
@@ -181,6 +181,11 @@
                 false-value="false">
               <label for="disabled">Disabled</label>
             </div>
+            <div class="form-input toggle">
+              <input type="checkbox" id="autoClose" v-model="paybuttonProps.autoClose" true-value="true"
+                false-value="false">
+              <label for="autoClose">Auto Close</label>
+            </div>
           </div>
         </div>
         <div style="display: flex; justify-content: right; position: relative;">
@@ -213,6 +218,7 @@
             :on-transaction="myTransactionFuction"
             :disable-altpayment="paybuttonProps.disableAltpayment"
             :transaction-text="paybuttonProps.transactionText"
+            :auto-close="paybuttonProps.autoClose"
             :op-return="paybuttonProps.opReturn">
           </div>
         </div>
@@ -247,7 +253,8 @@
             opReturn:undefined,
             transactiontext: '',
             onSuccess: mySuccessFuction,
-            onTransaction: myTransactionFuction
+            onTransaction: myTransactionFuction,
+            autoClose: true
           });
           const paybuttonType = ref("paybutton");
           const updateProps = () => {

--- a/react/lib/components/PayButton/PayButton.tsx
+++ b/react/lib/components/PayButton/PayButton.tsx
@@ -367,7 +367,7 @@ const payButtonDefaultProps: PayButtonProps = {
   disableEnforceFocus: false,
   disabled: false,
   editable: false,
-  autoClose: true,
+  autoClose: false,
 };
 
 PayButton.defaultProps = payButtonDefaultProps;

--- a/react/lib/components/PaymentDialog/PaymentDialog.tsx
+++ b/react/lib/components/PaymentDialog/PaymentDialog.tsx
@@ -140,7 +140,6 @@ export const PaymentDialog = (
     setSuccess(true);
     onSuccess?.(transaction);
     setTimeout(() => {
-      setSuccess(false);
       if (autoClose === true) {
         handleWidgetClose();
       }

--- a/react/lib/components/PaymentDialog/PaymentDialog.tsx
+++ b/react/lib/components/PaymentDialog/PaymentDialog.tsx
@@ -140,7 +140,7 @@ export const PaymentDialog = (
     setSuccess(true);
     onSuccess?.(transaction);
     setTimeout(() => {
-      if (autoClose === true) {
+      if (isPropsTrue(autoClose)) {
         handleWidgetClose();
       }
     }, 3000);

--- a/react/lib/components/Widget/WidgetContainer.tsx
+++ b/react/lib/components/Widget/WidgetContainer.tsx
@@ -198,9 +198,6 @@ export const WidgetContainer: React.FunctionComponent<WidgetContainerProps> =
               );
             setSuccess(true);
             onSuccess?.(transaction);
-            setTimeout(() => {
-              setSuccess(false);
-            }, 3000);
           } else {
             onTransaction?.(transaction);
             if (transactionText){


### PR DESCRIPTION
Related to #

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
- Set auto close to false by default 
- Added auto close prop to generator
- Removed undoing sucess by default


Test plan
---
Create a button, make a payment, check if the dialog keeps open
Also check if sucess checkmark remains there 

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
