### PR TITLE
Switched to the new cashtab-connect lib

### DIFF
--- a/react/lib/components/Widget/Widget.tsx
+++ b/react/lib/components/Widget/Widget.tsx
@@ -18,7 +18,7 @@ import {
   getAddressBalance,
   isFiat,
   Transaction,
-  getCashtabProviderStatus,
+  openCashtabPayment,
   DECIMALS,
   CurrencyObject,
   getCurrencyObject,
@@ -693,24 +693,9 @@ export const Widget: React.FunctionComponent<WidgetProps> = props => {
     }
   }, [totalReceived, currency, goalAmount, price, hasPrice, contributionOffset]);
 
-  const handleButtonClick = () => {
+  const handleButtonClick = async () => {
     if (thisAddressType === 'XEC') {
-      const hasExtension = getCashtabProviderStatus();
-      if (!hasExtension) {
-        const webUrl = `https://cashtab.com/#/send?bip21=${url}`;
-        window.open(webUrl, '_blank');
-      } else {
-        return window.postMessage(
-          {
-            type: 'FROM_PAGE',
-            text: 'Cashtab',
-            txInfo: {
-              bip21: url
-            },
-          },
-          '*',
-        );
-      }
+      await openCashtabPayment(url);
     } else {
       window.location.href = url;
     }

--- a/react/lib/util/api-client.ts
+++ b/react/lib/util/api-client.ts
@@ -97,11 +97,3 @@ export default {
   getAddressBalance,
 };
 
-export const getCashtabProviderStatus = () => {
-  const windowAny = window as any
-  if (window && windowAny.bitcoinAbc && windowAny.bitcoinAbc === 'cashtab') {
-    return true;
-  }
-  return false;
-};
-

--- a/react/lib/util/cashtab.ts
+++ b/react/lib/util/cashtab.ts
@@ -1,0 +1,95 @@
+import { 
+  CashtabConnect, 
+  CashtabExtensionUnavailableError,
+  CashtabAddressDeniedError,
+  CashtabTimeoutError 
+} from 'cashtab-connect';
+
+// Create a single instance to be reused throughout the app
+const cashtab = new CashtabConnect();
+
+/**
+ * Check if the Cashtab extension is available
+ * @returns Promise<boolean> - true if extension is available, false otherwise
+ */
+export const getCashtabProviderStatus = async (): Promise<boolean> => {
+  try {
+    return await cashtab.isExtensionAvailable();
+  } catch (error) {
+    return false;
+  }
+};
+
+/**
+ * Wait for the Cashtab extension to become available
+ * @param timeout - Maximum time to wait in milliseconds (default: 3000)
+ * @returns Promise that resolves when extension is available or rejects on timeout
+ */
+export const waitForCashtabExtension = async (timeout?: number): Promise<void> => {
+  return cashtab.waitForExtension(timeout);
+};
+
+/**
+ * Request the user's eCash address from their Cashtab wallet
+ * @returns Promise<string> - The user's address
+ * @throws {CashtabExtensionUnavailableError} When the Cashtab extension is not available
+ * @throws {CashtabAddressDeniedError} When the user denies the address request
+ * @throws {CashtabTimeoutError} When the request times out
+ */
+export const requestCashtabAddress = async (): Promise<string> => {
+  return cashtab.requestAddress();
+};
+
+/**
+ * Send XEC to an address using Cashtab
+ * @param address - Recipient's eCash address
+ * @param amount - Amount to send in XEC
+ * @throws {CashtabExtensionUnavailableError} When the Cashtab extension is not available
+ */
+export const sendXecWithCashtab = async (address: string, amount: string | number): Promise<any> => {
+  return cashtab.sendXec(address, amount);
+};
+
+/**
+ * Open Cashtab with a BIP21 payment URL
+ * @param bip21Url - The BIP21 formatted payment URL
+ * @param fallbackUrl - Optional fallback URL if extension is not available
+ */
+export const openCashtabPayment = async (bip21Url: string, fallbackUrl?: string): Promise<void> => {
+  try {
+    const isAvailable = await getCashtabProviderStatus();
+    
+    if (isAvailable) {
+      // For BIP21 URLs, we need to parse them to extract address and amount
+      // The cashtab-connect library expects separate address and amount parameters
+      const url = new URL(bip21Url);
+      const address = url.pathname;
+      const amount = url.searchParams.get('amount');
+      
+      if (amount) {
+        // If we have an amount, use the sendXec method
+        await sendXecWithCashtab(address, amount);
+      } else {
+        // If no amount, fall back to opening web Cashtab with the full BIP21 URL
+        const webUrl = fallbackUrl || `https://cashtab.com/#/send?bip21=${encodeURIComponent(bip21Url)}`;
+        window.open(webUrl, '_blank');
+      }
+    } else {
+      // Extension not available, open web Cashtab
+      const webUrl = fallbackUrl || `https://cashtab.com/#/send?bip21=${encodeURIComponent(bip21Url)}`;
+      window.open(webUrl, '_blank');
+    }
+  } catch (error) {
+    console.warn('Cashtab payment failed, falling back to web interface:', error);
+    // If extension interaction fails, fall back to web Cashtab
+    const webUrl = fallbackUrl || `https://cashtab.com/#/send?bip21=${encodeURIComponent(bip21Url)}`;
+    window.open(webUrl, '_blank');
+  }
+};
+
+// Export error types for consumers to handle specific errors
+export {
+  CashtabExtensionUnavailableError,
+  CashtabAddressDeniedError,
+  CashtabTimeoutError
+};

--- a/react/lib/util/index.ts
+++ b/react/lib/util/index.ts
@@ -1,5 +1,6 @@
 export * from './address';
 export * from './api-client';
+export * from './cashtab';
 export * from './constants';
 export * from './format';
 export * from './opReturn';

--- a/react/package.json
+++ b/react/package.json
@@ -88,6 +88,7 @@
     "@types/jest": "^29.5.11",
     "axios": "1.6.5",
     "bignumber.js": "9.0.2",
+    "cashtab-connect": "^1.1.0",
     "copy-to-clipboard": "3.3.3",
     "crypto-js": "^4.2.0",
     "jest": "^29.7.0",


### PR DESCRIPTION
Related to #516

<!-- Non-technical -->
Description
---
This change standardizes how we interact with both the Cashtab extension and (fallback) website.


Test plan
---
Initiate payments with the Cashtab extension installed and not installed.