### PR TITLE
fix: open cashtab with no amount

### DIFF
--- a/react/lib/util/cashtab.ts
+++ b/react/lib/util/cashtab.ts
@@ -86,16 +86,7 @@ export const openCashtabPayment = async (bip21Url: string, fallbackUrl?: string)
     const isAvailable = await getCashtabProviderStatus();
     
     if (isAvailable) {
-      const url = new URL(bip21Url);
-      const address = url.pathname;
-      const amount = url.searchParams.get('amount');
-      
-      if (amount) {
-        await sendXecWithCashtab(address, amount);
-      } else {
-        const webUrl = fallbackUrl || `https://cashtab.com/#/send?bip21=${encodeURIComponent(bip21Url)}`;
-        window.open(webUrl, '_blank');
-      }
+      cashtab.sendBip21(bip21Url);
     } else {
       const webUrl = fallbackUrl || `https://cashtab.com/#/send?bip21=${encodeURIComponent(bip21Url)}`;
       window.open(webUrl, '_blank');


### PR DESCRIPTION
Related to #537 

<!--
Depends on
---
- [ ] #
-->


<!-- Non-technical -->
Description
---
Use bip21 to open cashtab extension even if there is no amount set


Test plan
---
Create a button with an amount and check if cashtab extension opens, do the same with a button with no amount

<!-- Uncomment below to add any remarks, technical or not -->
<!-- 
Remarks
---
-->
