### PR TITLE
fix: base64 of success audio

### DIFF
--- a/react/lib/tests/assets/successSound.test.ts
+++ b/react/lib/tests/assets/successSound.test.ts
@@ -1,0 +1,15 @@
+import fs from 'fs';
+import path from 'path';
+import successSound from '../../assets/success.mp3.json';
+
+describe('success.mp3 and success.mp3.json', () => {
+  it('match: JSON base64 equals mp3 data URI', () => {
+    const mp3Path = path.resolve(__dirname, '../../assets/success.mp3');
+    const mp3Buffer = fs.readFileSync(mp3Path);
+    const dataUri = 'data:audio/mpeg;base64,' + mp3Buffer.toString('base64');
+    expect(successSound.base64).toBe(dataUri);
+  });
+});
+
+
+


### PR DESCRIPTION
Depends on
---
- [x] #544


<!-- Non-technical -->
Description
---
Added test to check that both the base64-encoded json file for the success.mp3 actually uses the success.mp3 in the same folder.


Test plan
---
1. Run the tests (I tried: `yarn run -s test -- --color=false`. It should pass.
2. Update `/react/lib/assets/success.mp3` to something else.
3. Run the tests again. They should now fail.

<!-- Uncomment below to add any remarks, technical or not -->
Remarks
---
We should add instructions for how to run the client repo tests in the main readme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a test suite to verify the success sound asset’s integrity by matching the JSON-encoded base64 data to the actual MP3 data URI.
  * Enhances CI coverage for media assets, ensuring the embedded audio reference remains accurate and preventing broken or mismatched sounds in the UI across builds and deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->