### PR TITLE
Adjustable auto-close

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1019,26 +1019,26 @@ contributionOffset = 10
 
 > **The ‘autoClose’ parameter automatically closes the payment dialog after a payment is received.**
 
-?> This parameter is optional. Default value is true. Possible values are true or false.
+?> This parameter is optional. Default is true (2 seconds). Possible values are true, false, or a number (seconds) to set a custom delay.
 **Example:**
 <!-- tabs:start -->
 
 #### ** HTML **
 
 ```html
-auto-close="false"
+auto-close="1"
 ```
 
 #### ** JavaScript **
 
 ```javascript
-autoClose: false
+autoClose: 1
 ```
 
 #### ** React **
 
 ```react
-autoClose = false
+autoClose = 1
 ```
 <!-- tabs:end -->
 

--- a/docs/zh-cn/README.md
+++ b/docs/zh-cn/README.md
@@ -1015,26 +1015,26 @@ contributionOffset = 10
 
 > **‘autoClose’ 收到付款后，参数会自动关闭付款对话框**
 
-?> 此参数为可选参数。默认值为 true。可能的值为 true 或 false。
+?> 此参数为可选参数。默认值为 true（2 秒）。可能的值为 true、false，或数字（单位：秒）以自定义延迟。
 **Example:**
 <!-- tabs:start -->
 
 #### ** HTML **
 
 ```html
-auto-close="false"
+auto-close="1"
 ```
 
 #### ** JavaScript **
 
 ```javascript
-autoClose: false
+autoClose: 1
 ```
 
 #### ** React **
 
 ```react
-autoClose = false
+autoClose = 1
 ```
 <!-- tabs:end -->
 

--- a/docs/zh-tw/README.md
+++ b/docs/zh-tw/README.md
@@ -1013,26 +1013,26 @@ contributionOffset = 10
 
 > **‘autoClose’ 收到付款後，參數會自動關閉付款對話框.**
 
-?> 此參數是可選的。預設值為 true。可能的值是真或假。
+?> 此參數是可選的。預設為 true（2 秒）。可接受 true、false，或數字（單位：秒）以自訂延遲。
 **Example:**
 <!-- tabs:start -->
 
 #### ** HTML **
 
 ```html
-auto-close="false"
+auto-close="1"
 ```
 
 #### ** JavaScript **
 
 ```javascript
-autoClose: false
+autoClose: 1
 ```
 
 #### ** React **
 
 ```react
-autoClose = false
+autoClose = 1
 ```
 <!-- tabs:end -->
 ## size

--- a/react/lib/components/PayButton/PayButton.tsx
+++ b/react/lib/components/PayButton/PayButton.tsx
@@ -51,7 +51,7 @@ export interface PayButtonProps extends ButtonProps {
   apiBaseUrl?: string;
   transactionText?: string;
   disableSound?: boolean;
-  autoClose?: boolean;
+  autoClose?: boolean | number | string;
   disableAltpayment?:boolean
   contributionOffset?:number
   size: ButtonSize;
@@ -370,7 +370,7 @@ const payButtonDefaultProps: PayButtonProps = {
   disableEnforceFocus: false,
   disabled: false,
   editable: false,
-  autoClose: false,
+  autoClose: true,
   size: 'md',
   sizeScaleAlreadyApplied: false,
 };

--- a/react/lib/components/PaymentDialog/PaymentDialog.tsx
+++ b/react/lib/components/PaymentDialog/PaymentDialog.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { Theme, ThemeName, ThemeProvider, useTheme } from '../../themes';
 import Button, { ButtonProps } from '../Button/Button';
 import { WidgetContainer } from '../Widget/WidgetContainer';
-import { Currency, CurrencyObject, Transaction, isPropsTrue, isValidCashAddress, isValidXecAddress } from '../../util';
+import { Currency, CurrencyObject, Transaction, isPropsTrue, isValidCashAddress, isValidXecAddress, AUTO_CLOSE_DEFAULT_MS } from '../../util';
 import { Socket } from 'socket.io-client';
 import { AltpaymentCoin, AltpaymentPair, AltpaymentShift, AltpaymentError } from '../../altpayment';
 export interface PaymentDialogProps extends ButtonProps {
@@ -129,16 +129,16 @@ export const PaymentDialog = (
   } = Object.assign({}, PaymentDialog.defaultProps, props);
 
   const getAutoCloseDelay = (value: PaymentDialogProps['autoClose']): number | undefined => {
-    if (value === undefined) return 2000; // default when not provided (enabled)
-    if (typeof value === 'boolean') return value ? 2000 : undefined;
+    if (value === undefined) return AUTO_CLOSE_DEFAULT_MS; // default when not provided (enabled)
+    if (typeof value === 'boolean') return value ? AUTO_CLOSE_DEFAULT_MS : undefined;
     if (typeof value === 'number') return value > 0 ? Math.round(value * 1000) : undefined;
     if (typeof value === 'string') {
       const trimmed = value.trim().toLowerCase();
-      if (trimmed === 'true') return 2000;
+      if (trimmed === 'true') return AUTO_CLOSE_DEFAULT_MS;
       if (trimmed === 'false') return undefined;
       const num = +trimmed;
       if (!isNaN(num)) return num > 0 ? Math.round(num * 1000) : undefined;
-      return 2000; // treat unknown string as enabled default
+      return AUTO_CLOSE_DEFAULT_MS; // treat unknown string as enabled default
     }
     return undefined;
   };

--- a/react/lib/tests/util/autoClose.test.ts
+++ b/react/lib/tests/util/autoClose.test.ts
@@ -1,0 +1,45 @@
+import { getAutoCloseDelay } from '../../util/autoClose';
+import { AUTO_CLOSE_DEFAULT_MS } from '../../util/constants';
+
+describe('getAutoCloseDelay', () => {
+  it('returns default delay for undefined', () => {
+    expect(getAutoCloseDelay(undefined)).toBe(AUTO_CLOSE_DEFAULT_MS);
+  });
+
+  it('returns default delay for true', () => {
+    expect(getAutoCloseDelay(true)).toBe(AUTO_CLOSE_DEFAULT_MS);
+  });
+
+  it('returns undefined for false (disabled)', () => {
+    expect(getAutoCloseDelay(false)).toBeUndefined();
+  });
+
+  it('returns rounded ms for positive numeric seconds', () => {
+    expect(getAutoCloseDelay(1)).toBe(1000);
+    expect(getAutoCloseDelay(1.234)).toBe(1234);
+  });
+
+  it('returns undefined for zero or negative numeric values', () => {
+    expect(getAutoCloseDelay(0)).toBeUndefined();
+    expect(getAutoCloseDelay(-1)).toBeUndefined();
+    expect(getAutoCloseDelay(-0.5)).toBeUndefined();
+  });
+
+  it('parses string booleans correctly', () => {
+    expect(getAutoCloseDelay('true')).toBe(AUTO_CLOSE_DEFAULT_MS);
+    expect(getAutoCloseDelay(' false ')).toBeUndefined();
+  });
+
+  it('parses numeric strings as seconds', () => {
+    expect(getAutoCloseDelay('2')).toBe(2000);
+    expect(getAutoCloseDelay(' 2.5 ')).toBe(2500);
+    expect(getAutoCloseDelay('0')).toBeUndefined();
+    expect(getAutoCloseDelay('-3')).toBeUndefined();
+  });
+
+  it('falls back to default for non-numeric, non-boolean strings', () => {
+    expect(getAutoCloseDelay('abc')).toBe(AUTO_CLOSE_DEFAULT_MS);
+  });
+});
+
+

--- a/react/lib/util/autoClose.ts
+++ b/react/lib/util/autoClose.ts
@@ -1,0 +1,28 @@
+import { AUTO_CLOSE_DEFAULT_MS } from './constants';
+
+export type AutoCloseValue = boolean | number | string | undefined;
+
+/**
+ * Determine auto-close delay (ms) from a variety of allowed input types.
+ * Rules:
+ * - undefined -> default enabled delay
+ * - boolean -> true: default delay; false: disabled (undefined)
+ * - number -> >0 seconds: round to nearest ms; <=0: disabled
+ * - string -> 'true': default; 'false': disabled; numeric string parsed like number; other strings: default
+ */
+export function getAutoCloseDelay(value: AutoCloseValue): number | undefined {
+  if (value === undefined) return AUTO_CLOSE_DEFAULT_MS;
+  if (typeof value === 'boolean') return value ? AUTO_CLOSE_DEFAULT_MS : undefined;
+  if (typeof value === 'number') return value > 0 ? Math.round(value * 1000) : undefined;
+  if (typeof value === 'string') {
+    const trimmed = value.trim().toLowerCase();
+    if (trimmed === 'true') return AUTO_CLOSE_DEFAULT_MS;
+    if (trimmed === 'false') return undefined;
+    const num = +trimmed;
+    if (!isNaN(num)) return num > 0 ? Math.round(num * 1000) : undefined;
+    return AUTO_CLOSE_DEFAULT_MS;
+  }
+  return undefined;
+}
+
+

--- a/react/lib/util/constants.ts
+++ b/react/lib/util/constants.ts
@@ -8,6 +8,9 @@ export const DECIMALS: { [key: string]: number } = {
     FIAT: 2,
 };
 
+// Default delay (ms) before auto-closing success dialog when autoClose is enabled
+export const AUTO_CLOSE_DEFAULT_MS = 2000;
+
 export const CURRENCY_PREFIXES_MAP: Record<typeof CRYPTO_CURRENCIES[number], string> = {
     bch: 'bitcoincash',
     xec: 'ecash',

--- a/react/lib/util/index.ts
+++ b/react/lib/util/index.ts
@@ -11,4 +11,5 @@ export * from './types';
 export * from './number';
 export * from './currency';
 export * from './validate';
+export * from './autoClose';
 


### PR DESCRIPTION
Related to #548

<!-- Non-technical -->
Description
---
Updated the auto-close parameter to allow entering a valid positive number (decimals are fine).


Test plan
---
Create a button with a custom auto-close duration and see that it meets expectations.

Remarks
---
This branch also makes auto-close = true by default which is what it was intended to be, also reducing the default (previously only) auto-close timer from 3s -> 2s.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-close now accepts a configurable delay (seconds) as well as true/false.
  * Default success dialog now auto-closes after 2 seconds.

* **Documentation**
  * Examples updated to use numeric delay values.
  * Docs clarified accepted auto-close values (true, false, or numeric seconds) across English, zh-CN, and zh-TW.

* **Tests**
  * Added unit tests covering the auto-close parsing and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->